### PR TITLE
chore: include package summary page in toc

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
@@ -71,6 +71,7 @@ public class YmlFilesBuilder {
             packageMetadataFiles.add(buildPackageMetadataFile(packageElement));
 
             TocItem packageTocItem = new TocItem(uid, uid);
+            packageTocItem.getItems().add(new TocItem(uid, "Package summary"));
             buildFilesForInnerClasses(packageElement, packageTocItem.getItems(), classMetadataFiles);
             tocFile.addTocItem(packageTocItem);
         }

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/toc.yml
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/toc.yml
@@ -8,6 +8,8 @@
   - uid: "com.microsoft.samples"
     name: "com.microsoft.samples"
     items:
+    - uid: "com.microsoft.samples"
+      name: "Package summary"
     - uid: "com.microsoft.samples.BasePartnerComponent"
       name: "BasePartnerComponent"
     - uid: "com.microsoft.samples.BasePartnerComponentString"
@@ -25,6 +27,8 @@
   - uid: "com.microsoft.samples.agreements"
     name: "com.microsoft.samples.agreements"
     items:
+    - uid: "com.microsoft.samples.agreements"
+      name: "Package summary"
     - uid: "com.microsoft.samples.agreements.AgreementDetailsCollectionOperations"
       name: "AgreementDetailsCollectionOperations"
     - uid: "com.microsoft.samples.agreements.AgreementMetaData"
@@ -36,6 +40,8 @@
   - uid: "com.microsoft.samples.commentinheritance"
     name: "com.microsoft.samples.commentinheritance"
     items:
+    - uid: "com.microsoft.samples.commentinheritance"
+      name: "Package summary"
     - uid: "com.microsoft.samples.commentinheritance.Animal"
       name: "Animal"
     - uid: "com.microsoft.samples.commentinheritance.Carnivorous"
@@ -57,6 +63,8 @@
   - uid: "com.microsoft.samples.google"
     name: "com.microsoft.samples.google"
     items:
+    - uid: "com.microsoft.samples.google"
+      name: "Package summary"
     - uid: "com.microsoft.samples.google.ProductSearchSettings"
       name: "ProductSearchSettings"
     - uid: "com.microsoft.samples.google.ProductSearchSettings.Builder"
@@ -74,11 +82,15 @@
   - uid: "com.microsoft.samples.offers"
     name: "com.microsoft.samples.offers"
     items:
+    - uid: "com.microsoft.samples.offers"
+      name: "Package summary"
     - uid: "com.microsoft.samples.offers.Offer"
       name: "Offer"
   - uid: "com.microsoft.samples.subpackage"
     name: "com.microsoft.samples.subpackage"
     items:
+    - uid: "com.microsoft.samples.subpackage"
+      name: "Package summary"
     - uid: "com.microsoft.samples.subpackage.CustomException"
       name: "CustomException"
     - uid: "com.microsoft.samples.subpackage.Display"


### PR DESCRIPTION
Fixes b/194728230

The package summary pages were already being generated but were not included in the toc. See /java/docs/reference/api-common/latest/com.google.api.core.html as an example.

Updated doc-template goldens with output [here](https://github.com/googleapis/doc-templates/pull/277)