### PR TITLE
chore: refactor YmlFilesBuilder

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/BuilderUtil.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/BuilderUtil.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.microsoft.lookup.BaseLookup;
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+import com.microsoft.model.SpecViewModel;
+import com.microsoft.util.YamlUtil;
+import org.apache.commons.lang3.RegExUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.lang.model.element.Element;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class BuilderUtil {
+    private static final Pattern XREF_LINK_PATTERN = Pattern.compile("<xref uid=\".*?\" .*?>.*?</xref>");
+    private static final Pattern XREF_LINK_CONTENT_PATTERN = Pattern.compile("(?<=<xref uid=\").*?(?=\" .*?>.*?</xref>)");
+    private static final Pattern XREF_LINK_RESOLVE_PATTERN = Pattern.compile("(?<class>\\w+)\\#(?<member>\\w+)(\\((?<param>.*)\\))?");
+    public final static String[] LANGS = {"java"};
+
+    static String getDeprecatedSummary(String depMsg, String summary) {
+        String result = "<p>(deprecated) " + depMsg + "</p>";
+        if (summary != null && !summary.equals("")) {
+            result = result + "\n" + summary;
+        }
+        return result;
+    }
+
+    static String populateUidValues(String text, LookupContext lookupContext) {
+        if (StringUtils.isBlank(text)) {
+            return text;
+        }
+
+        Matcher linkMatcher = XREF_LINK_PATTERN.matcher(text);
+        while (linkMatcher.find()) {
+            String link = linkMatcher.group();
+            Matcher linkContentMatcher = XREF_LINK_CONTENT_PATTERN.matcher(link);
+            if (!linkContentMatcher.find()) {
+                continue;
+            }
+
+            String linkContent = linkContentMatcher.group();
+            String uid = resolveUidFromLinkContent(linkContent, lookupContext);
+            String updatedLink = linkContentMatcher.replaceAll(uid);
+            text = StringUtils.replace(text, link, updatedLink);
+        }
+        return text;
+    }
+
+    /**
+     * The linkContent could be in following format
+     * #memeber
+     * Class#member
+     * Class#method()
+     * Class#method(params)
+     */
+    static String resolveUidFromLinkContent(String linkContent, LookupContext lookupContext) {
+        if (StringUtils.isBlank(linkContent)) {
+            return "";
+        }
+
+        linkContent = linkContent.trim();
+
+        // complete class name for class internal link
+        if (linkContent.startsWith("#")) {
+            String firstKey = lookupContext.getOwnerUid();
+            linkContent = firstKey + linkContent;
+        }
+
+        // fuzzy resolve, target for items from project external references
+        String fuzzyResolvedUid = resolveUidFromReference(linkContent, lookupContext);
+
+        // exact resolve in lookupContext
+        linkContent = linkContent.replace("#", ".");
+        String exactResolveUid = resolveUidByLookup(linkContent, lookupContext);
+        return exactResolveUid.isEmpty() ? fuzzyResolvedUid : exactResolveUid;
+    }
+
+    static List<String> splitUidWithGenericsIntoClassNames(String uid) {
+        uid = RegExUtils.removeAll(uid, "[>]+$");
+        return Arrays.asList(StringUtils.split(uid, "<"));
+    }
+
+    static List<String> replaceUidAndSplit(String uid) {
+        String retValue = RegExUtils.replaceAll(uid, "\\<", "//<//");
+        retValue = RegExUtils.replaceAll(retValue, "\\>", "//>//");
+        retValue = RegExUtils.replaceAll(retValue, ",", "//,//");
+        retValue = RegExUtils.replaceAll(retValue, "\\[\\]", "//[]//");
+
+        return Arrays.asList(StringUtils.split(retValue, "//"));
+    }
+
+    static List<SpecViewModel> getJavaSpec(List<String> references) {
+        List<SpecViewModel> specList = new ArrayList<>();
+
+        Optional.ofNullable(references).ifPresent(
+                ref -> references.forEach(
+                        uid -> {
+                            if (uid.equalsIgnoreCase("<")
+                                    || uid.equalsIgnoreCase(">")
+                                    || uid.equalsIgnoreCase(",")
+                                    || uid.equalsIgnoreCase("[]"))
+                                specList.add(new SpecViewModel(null, uid));
+                            else if (uid != "")
+                                specList.add(new SpecViewModel(uid, uid));
+                        })
+        );
+
+        return specList;
+    }
+
+    static void populateUidValues(List<MetadataFile> packageMetadataFiles, List<MetadataFile> classMetadataFiles) {
+        Lookup lookup = new Lookup(packageMetadataFiles, classMetadataFiles);
+
+        classMetadataFiles.forEach(classMetadataFile -> {
+            LookupContext lookupContext = lookup.buildContext(classMetadataFile);
+
+            for (MetadataFileItem item : classMetadataFile.getItems()) {
+                item.setSummary(YamlUtil.cleanupHtml(
+                        populateUidValues(item.getSummary(), lookupContext)
+                ));
+
+                Optional.ofNullable(item.getSyntax()).ifPresent(syntax -> {
+                            Optional.ofNullable(syntax.getParameters()).ifPresent(
+                                    methodParams -> methodParams.forEach(
+                                            param -> {
+                                                param.setDescription(populateUidValues(param.getDescription(), lookupContext));
+                                            })
+                            );
+                            Optional.ofNullable(syntax.getReturnValue()).ifPresent(returnValue ->
+                                    returnValue.setReturnDescription(
+                                            populateUidValues(syntax.getReturnValue().getReturnDescription(), lookupContext)
+                                    )
+                            );
+                        }
+                );
+            }
+        });
+    }
+
+    /**
+     * this method is used to do fuzzy resolve
+     * "*" will be added at the end of uid for method for xerf service resolve purpose
+     */
+    static String resolveUidFromReference(String linkContent, LookupContext lookupContext) {
+        String uid = "";
+        Matcher matcher = XREF_LINK_RESOLVE_PATTERN.matcher(linkContent);
+
+        if (matcher.find()) {
+            String className = matcher.group("class");
+            String memberName = matcher.group("member");
+            uid = resolveUidByLookup(className, lookupContext);
+            if (!uid.isEmpty()) {
+                uid = uid.concat(".").concat(memberName);
+
+                // linkContent targets a method
+                if (!StringUtils.isBlank(matcher.group(3))) {
+                    uid = uid.concat("*");
+                }
+            }
+        }
+        return uid;
+    }
+
+    static String resolveUidByLookup(String signature, LookupContext lookupContext) {
+        if (StringUtils.isBlank(signature) || lookupContext == null) {
+            return "";
+        }
+        return lookupContext.containsKey(signature) ? lookupContext.resolve(signature) : "";
+    }
+
+    static <T extends Element> void populateItemFields(MetadataFileItem item, BaseLookup<T> lookup, T element) {
+        String name = lookup.extractName(element);
+        item.setName(name);
+        item.setNameWithType(lookup.extractNameWithType(element));
+        item.setFullName(lookup.extractFullName(element));
+        item.setType(lookup.extractType(element));
+        item.setJavaType(lookup.extractJavaType(element));
+        item.setSummary(lookup.extractSummary(element));
+        item.setContent(lookup.extractContent(element));
+    }
+}

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ClassBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ClassBuilder.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.microsoft.lookup.ClassItemsLookup;
+import com.microsoft.lookup.ClassLookup;
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+import com.microsoft.model.Status;
+import com.microsoft.model.TocItem;
+import com.microsoft.model.TocTypeMap;
+import com.microsoft.util.ElementUtil;
+import com.microsoft.util.Utils;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.microsoft.build.BuilderUtil.LANGS;
+import static com.microsoft.build.BuilderUtil.getDeprecatedSummary;
+import static com.microsoft.build.BuilderUtil.populateItemFields;
+
+class ClassBuilder {
+    private ElementUtil elementUtil;
+    private ClassLookup classLookup;
+    private ClassItemsLookup classItemsLookup;
+    private String outputPath;
+    private ReferenceBuilder referenceBuilder;
+
+    ClassBuilder(ElementUtil elementUtil, ClassLookup classLookup, ClassItemsLookup classItemsLookup, String outputPath, ReferenceBuilder referenceBuilder) {
+        this.elementUtil = elementUtil;
+        this.classLookup = classLookup;
+        this.classItemsLookup = classItemsLookup;
+        this.outputPath = outputPath;
+        this.referenceBuilder = referenceBuilder;
+    }
+
+    void buildFilesForInnerClasses(Element element, TocTypeMap tocTypeMap, List<MetadataFile> container) {
+        for (TypeElement classElement : elementUtil.extractSortedElements(element)) {
+            String uid = classLookup.extractUid(classElement);
+            String name = classLookup.extractTocName(classElement);
+            String status = classLookup.extractStatus(classElement);
+
+            if (tocTypeMap.get(classElement.getKind().name()) != null) {
+                if (classElement.getKind().name().equals(ElementKind.CLASS.name()) && name.contains("Exception")) {
+                    tocTypeMap.get("EXCEPTION").add(new TocItem(uid, name, status));
+                } else {
+                    tocTypeMap.get(classElement.getKind().name()).add(new TocItem(uid, name, status));
+                }
+            } else {
+                tocTypeMap.get(ElementKind.CLASS.name()).add(new TocItem(uid, name, status));
+            }
+
+            container.add(buildClassYmlFile(classElement));
+            buildFilesForInnerClasses(classElement, tocTypeMap, container);
+        }
+    }
+
+    private MetadataFile buildClassYmlFile(TypeElement classElement) {
+        String fileName = classLookup.extractHref(classElement);
+        MetadataFile classMetadataFile = new MetadataFile(outputPath, fileName);
+        addClassInfo(classElement, classMetadataFile);
+        addConstructorsInfo(classElement, classMetadataFile);
+        addMethodsInfo(classElement, classMetadataFile);
+        addFieldsInfo(classElement, classMetadataFile);
+        referenceBuilder.addReferencesInfo(classElement, classMetadataFile);
+        applyPostProcessing(classMetadataFile);
+        return classMetadataFile;
+    }
+
+    private void addClassInfo(TypeElement classElement, MetadataFile classMetadataFile) {
+        MetadataFileItem classItem = new MetadataFileItem(LANGS, classLookup.extractUid(classElement));
+        classItem.setId(classLookup.extractId(classElement));
+        classItem.setParent(classLookup.extractParent(classElement));
+        addChildren(classElement, classItem.getChildren());
+        populateItemFields(classItem, classLookup, classElement);
+        classItem.setPackageName(classLookup.extractPackageName(classElement));
+        classItem.setTypeParameters(classLookup.extractTypeParameters(classElement));
+        classItem.setInheritance(classLookup.extractSuperclass(classElement));
+        classItem.setInterfaces(classLookup.extractInterfaces(classElement));
+        classItem.setInheritedMethods(classLookup.extractInheritedMethods(classElement));
+        String depMsg = classLookup.extractDeprecatedDescription(classElement);
+        if (depMsg != null) {
+            classItem.setSummary(getDeprecatedSummary(depMsg, classItem.getSummary()));
+            classItem.setStatus(Status.DEPRECATED.toString());
+        }
+        classMetadataFile.getItems().add(classItem);
+    }
+
+    void addConstructorsInfo(TypeElement classElement, MetadataFile classMetadataFile) {
+        for (ExecutableElement constructorElement : ElementFilter.constructorsIn(classElement.getEnclosedElements())) {
+            MetadataFileItem constructorItem = buildMetadataFileItem(constructorElement);
+            constructorItem.setOverload(classItemsLookup.extractOverload(constructorElement));
+            constructorItem.setContent(classItemsLookup.extractConstructorContent(constructorElement));
+            constructorItem.setParameters(classItemsLookup.extractParameters(constructorElement));
+            String depMsg = classItemsLookup.extractDeprecatedDescription(constructorElement);
+            if (depMsg != null) {
+                constructorItem.setSummary(getDeprecatedSummary(depMsg, constructorItem.getSummary()));
+                constructorItem.setStatus(Status.DEPRECATED.toString());
+            }
+            classMetadataFile.getItems().add(constructorItem);
+
+            referenceBuilder.addParameterReferences(constructorItem, classMetadataFile);
+            referenceBuilder.addOverloadReferences(constructorItem, classMetadataFile);
+        }
+    }
+
+    private void addMethodsInfo(TypeElement classElement, MetadataFile classMetadataFile) {
+        ElementFilter.methodsIn(classElement.getEnclosedElements()).stream()
+                .filter(methodElement -> !Utils.isPrivateOrPackagePrivate(methodElement))
+                .forEach(methodElement -> {
+                    MetadataFileItem methodItem = buildMetadataFileItem(methodElement);
+                    methodItem.setOverload(classItemsLookup.extractOverload(methodElement));
+                    methodItem.setContent(classItemsLookup.extractMethodContent(methodElement));
+                    methodItem.setExceptions(classItemsLookup.extractExceptions(methodElement));
+                    methodItem.setParameters(classItemsLookup.extractParameters(methodElement));
+                    methodItem.setReturn(classItemsLookup.extractReturn(methodElement));
+                    methodItem.setOverridden(classItemsLookup.extractOverridden(methodElement));
+                    String depMsg = classItemsLookup.extractDeprecatedDescription(methodElement);
+                    if (depMsg != null) {
+                        methodItem.setSummary(getDeprecatedSummary(depMsg, methodItem.getSummary()));
+                        methodItem.setStatus(Status.DEPRECATED.toString());
+                    }
+
+                    classMetadataFile.getItems().add(methodItem);
+                    referenceBuilder.addExceptionReferences(methodItem, classMetadataFile);
+                    referenceBuilder.addParameterReferences(methodItem, classMetadataFile);
+                    referenceBuilder.addReturnReferences(methodItem, classMetadataFile);
+                    referenceBuilder.addOverloadReferences(methodItem, classMetadataFile);
+                });
+    }
+
+    private void addFieldsInfo(TypeElement classElement, MetadataFile classMetadataFile) {
+        ElementFilter.fieldsIn(classElement.getEnclosedElements()).stream()
+                .filter(fieldElement -> !Utils.isPrivateOrPackagePrivate(fieldElement))
+                .forEach(fieldElement -> {
+                    MetadataFileItem fieldItem = buildMetadataFileItem(fieldElement);
+                    fieldItem.setContent(classItemsLookup.extractFieldContent(fieldElement));
+                    fieldItem.setReturn(classItemsLookup.extractReturn(fieldElement));
+                    String depMsg = classItemsLookup.extractDeprecatedDescription(fieldElement);
+                    if (depMsg != null) {
+                        fieldItem.setSummary(getDeprecatedSummary(depMsg, fieldItem.getSummary()));
+                        fieldItem.setStatus(Status.DEPRECATED.toString());
+                    }
+
+                    classMetadataFile.getItems().add(fieldItem);
+                    referenceBuilder.addReturnReferences(fieldItem, classMetadataFile);
+                });
+    }
+
+    private void applyPostProcessing(MetadataFile classMetadataFile) {
+        referenceBuilder.expandComplexGenericsInReferences(classMetadataFile);
+    }
+
+    private MetadataFileItem buildMetadataFileItem(Element element) {
+        return new MetadataFileItem(LANGS, classItemsLookup.extractUid(element)) {{
+            String name = classItemsLookup.extractName(element);
+            setId(classItemsLookup.extractId(element));
+            setParent(classItemsLookup.extractParent(element));
+            setName(name);
+            setNameWithType(classItemsLookup.extractNameWithType(element));
+            setFullName(classItemsLookup.extractFullName(element));
+            setType(classItemsLookup.extractType(element));
+            setJavaType(classItemsLookup.extractJavaType(element));
+            setPackageName(classItemsLookup.extractPackageName(element));
+            setSummary(classItemsLookup.extractSummary(element));
+        }};
+    }
+
+    private void addChildren(TypeElement classElement, List<String> children) {
+        collect(classElement, children, ElementFilter::constructorsIn, classItemsLookup::extractUid);
+        collect(classElement, children, ElementFilter::methodsIn, classItemsLookup::extractUid);
+        collect(classElement, children, ElementFilter::fieldsIn, classItemsLookup::extractUid);
+        collect(classElement, children, ElementFilter::typesIn, String::valueOf);
+    }
+
+    private void collect(TypeElement classElement, List<String> children,
+                 Function<Iterable<? extends Element>, List<? extends Element>> selectFunc,
+                 Function<? super Element, String> mapFunc) {
+
+        List<? extends Element> elements = selectFunc.apply(classElement.getEnclosedElements());
+        children.addAll(filterPrivateElements(elements).stream()
+                .map(mapFunc).collect(Collectors.toList()));
+    }
+
+    private List<? extends Element> filterPrivateElements(List<? extends Element> elements) {
+        return elements.stream()
+                .filter(element -> !Utils.isPrivateOrPackagePrivate(element)).collect(Collectors.toList());
+    }
+}

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.microsoft.lookup.PackageLookup;
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+
+import javax.lang.model.element.PackageElement;
+
+import static com.microsoft.build.BuilderUtil.LANGS;
+import static com.microsoft.build.BuilderUtil.populateItemFields;
+
+class PackageBuilder {
+    private final PackageLookup packageLookup;
+    private final String outputPath;
+    private final ReferenceBuilder referenceBuilder;
+
+    PackageBuilder(PackageLookup packageLookup, String outputPath, ReferenceBuilder referenceBuilder) {
+        this.packageLookup = packageLookup;
+        this.outputPath = outputPath;
+        this.referenceBuilder = referenceBuilder;
+    }
+
+    MetadataFile buildPackageMetadataFile(PackageElement packageElement) {
+        String fileName = packageLookup.extractHref(packageElement);
+        MetadataFile packageMetadataFile = new MetadataFile(outputPath, fileName);
+        MetadataFileItem packageItem = new MetadataFileItem(LANGS, packageLookup.extractUid(packageElement));
+        packageItem.setId(packageLookup.extractId(packageElement));
+        referenceBuilder.addChildrenReferences(packageElement, packageItem.getChildren(), packageMetadataFile.getReferences());
+        populateItemFields(packageItem, packageLookup, packageElement);
+        packageMetadataFile.getItems().add(packageItem);
+        return packageMetadataFile;
+    }
+}

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ProjectBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ProjectBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.build.BuilderUtil.LANGS;
+
+class ProjectBuilder {
+    private final String projectName;
+
+    ProjectBuilder(String projectName) {
+        this.projectName = projectName;
+    }
+
+    void buildProjectMetadataFile(List<MetadataFileItem> packageItems, MetadataFile projectMetadataFile) {
+        MetadataFileItem projectItem = new MetadataFileItem(LANGS, projectName);
+        projectItem.setNameWithType(projectName);
+        projectItem.setFullName(projectName);
+        projectItem.setType("Namespace");
+        projectItem.setJavaType("overview");
+
+        List<String> children = new ArrayList<>();
+        List<MetadataFileItem> references = new ArrayList<>();
+        packageItems.stream().forEach(i -> {
+            children.add(i.getUid());
+            MetadataFileItem refItem = new MetadataFileItem(i.getUid());
+            refItem.setName(i.getName());
+            refItem.setNameWithType(i.getNameWithType());
+            refItem.setFullName(i.getFullName());
+            references.add(refItem);
+        });
+
+        projectItem.getChildren().addAll(children);
+        projectMetadataFile.getReferences().addAll(references);
+        projectMetadataFile.getItems().add(projectItem);
+    }
+}

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ReferenceBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ReferenceBuilder.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.microsoft.lookup.ClassLookup;
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+import com.microsoft.model.SpecViewModel;
+import com.microsoft.util.ElementUtil;
+import jdk.javadoc.doclet.DocletEnvironment;
+import org.apache.commons.lang3.RegExUtils;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.microsoft.build.BuilderUtil.getJavaSpec;
+import static com.microsoft.build.BuilderUtil.populateItemFields;
+import static com.microsoft.build.BuilderUtil.replaceUidAndSplit;
+import static com.microsoft.build.BuilderUtil.splitUidWithGenericsIntoClassNames;
+
+class ReferenceBuilder {
+    private final Pattern JAVA_PATTERN = Pattern.compile("^java.*");
+    private final Pattern PROTOBUF_PATTERN = Pattern.compile("^com.google.protobuf.*");
+    private final Pattern GAX_PATTERN = Pattern.compile("^com.google.api.gax.*");
+    private final Pattern APICOMMON_PATTERN = Pattern.compile("^com.google.api.core.*");
+    private final Pattern LONGRUNNING_PATTERN = Pattern.compile("^com.google.longrunning.*");
+    private final Pattern ENDING_PATTERN = Pattern.compile(".*<\\?>$");
+    private final String PRIMITIVE_URL = "https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html";
+    private final String JAVA_BASE_URL = "https://docs.oracle.com/javase/8/docs/api/";
+    private final DocletEnvironment environment;
+    private final ClassLookup classLookup;
+    private final ElementUtil elementUtil;
+
+    ReferenceBuilder(DocletEnvironment environment, ClassLookup classLookup, ElementUtil elementUtil) {
+        this.environment = environment;
+        this.classLookup = classLookup;
+        this.elementUtil = elementUtil;
+    }
+
+    MetadataFileItem buildClassReference(TypeElement classElement) {
+        MetadataFileItem referenceItem = new MetadataFileItem(classLookup.extractUid(classElement));
+        referenceItem.setName(classLookup.extractName(classElement));
+        referenceItem.setNameWithType(classLookup.extractNameWithType(classElement));
+        referenceItem.setFullName(classLookup.extractFullName(classElement));
+        return referenceItem;
+    }
+
+    void addReferencesInfo(TypeElement classElement, MetadataFile classMetadataFile) {
+        MetadataFileItem classReference = new MetadataFileItem(classLookup.extractUid(classElement));
+        classReference.setParent(classLookup.extractParent(classElement));
+        populateItemFields(classReference, classLookup, classElement);
+        classReference.setTypeParameters(classLookup.extractTypeParameters(classElement));
+
+        addTypeParameterReferences(classReference, classMetadataFile);
+        addSuperclassAndInterfacesReferences(classElement, classMetadataFile);
+        addInnerClassesReferences(classElement, classMetadataFile);
+    }
+
+    void addChildrenReferences(Element element, List<String> packageChildren,
+                               Set<MetadataFileItem> referencesCollector) {
+        for (TypeElement classElement : elementUtil.extractSortedElements(element)) {
+            referencesCollector.add(buildClassReference(classElement));
+
+            packageChildren.add(classLookup.extractUid(classElement));
+            addChildrenReferences(classElement, packageChildren, referencesCollector);
+        }
+    }
+
+    String getJavaReferenceHref(String uid) {
+        if (uid == null || uid.equals("")) {
+            return JAVA_BASE_URL;
+        }
+        //  example1 uid: "java.lang.Object.equals(java.lang.Object)"
+        //  example2 uid: "java.lang.Object"
+        String endURL = uid.replaceAll("<T>", "");
+
+        Pattern argPattern = Pattern.compile(".*\\(.*\\).*");
+        if (argPattern.matcher(endURL).find()) {
+            // example1
+            // argumentSplit: ["java.lang.Object.equals", "java.lang.Object)"]
+            // nameSplit: ["java", "lang", "Object", "equals"]
+            List<String> argumentSplit = Arrays.asList(endURL.split("\\("));
+            List<String> nameSplit = Arrays.asList(argumentSplit.get(0).split("\\."));
+
+            // className: "java/lang/Object"
+            // methodName: "#equals"
+            // argumentsName: "#java.lang.Object-"
+            String className = String.join("/", nameSplit.subList(0, nameSplit.size() - 1));
+            String methodName = "#" + nameSplit.get(nameSplit.size() - 1);
+            String argumentsName = argumentSplit.get(1).replaceAll("[,)]", "-");
+
+            // endURL: "java/lang/Object.html#equals-java.lang.Object-"
+            endURL = className + ".html" + methodName + "-" + argumentsName;
+        } else {
+            // example2
+            // endURL = java/lang/Object.html
+            endURL = endURL.replaceAll("\\.", "/");
+            endURL = endURL + ".html";
+        }
+        return JAVA_BASE_URL + endURL;
+    }
+
+    void updateExternalReferences(List<MetadataFile> classMetadataFiles) {
+        classMetadataFiles.forEach(file -> file.getReferences()
+                .forEach(ref -> updateExternalReference(ref)));
+    }
+
+    private void updateExternalReference(MetadataFileItem reference) {
+        String uid = reference.getUid();
+        uid = updateReferenceUid(uid);
+
+        if (isJavaPrimitive(uid)) {
+            reference.setHref(PRIMITIVE_URL);
+            return;
+        }
+        if (isJavaLibrary(uid)) {
+            reference.setHref(getJavaReferenceHref(uid));
+        }
+        if (isExternalReference(uid)) {
+            reference.setIsExternal(true);
+        }
+        if (reference.getSpecForJava().size() > 0) {
+            for (SpecViewModel spec : reference.getSpecForJava()) {
+                String specUid = spec.getUid();
+                if (specUid != null) {
+                    if (isJavaPrimitive(specUid)) {
+                        spec.setHref(PRIMITIVE_URL);
+                    }
+                    if (isJavaLibrary(specUid)) {
+                        spec.setHref(getJavaReferenceHref(specUid));
+                    }
+                    if (isExternalReference(specUid)) {
+                        spec.setIsExternal(true);
+                    }
+                }
+            }
+        }
+    }
+
+    private String updateReferenceUid(String uid) {
+        if (ENDING_PATTERN.matcher(uid).find()) {
+            uid = uid.replace("<?>", "");
+        }
+        return uid;
+    }
+
+    private boolean isExternalReference(String uid) {
+        return (PROTOBUF_PATTERN.matcher(uid).find() || GAX_PATTERN.matcher(uid).find() || APICOMMON_PATTERN.matcher(uid).find() || GAX_PATTERN.matcher(uid).find() || LONGRUNNING_PATTERN.matcher(uid).find());
+    }
+
+    private boolean isJavaPrimitive(String uid) {
+        return (uid.equals("boolean") || uid.equals("int") || uid.equals("byte") || uid.equals("long") || uid.equals("float") || uid.equals("double") || uid.equals("char") || uid.equals("short"));
+    }
+
+    private boolean isJavaLibrary(String uid) {
+        return JAVA_PATTERN.matcher(uid).find();
+    }
+
+    void addParameterReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
+        classMetadataFile.getReferences().addAll(
+                methodItem.getSyntax().getParameters().stream()
+                        .map(parameter -> buildRefItem(parameter.getType()))
+                        .filter(o -> !classMetadataFile.getItems().contains(o))
+                        .collect(Collectors.toList()));
+    }
+
+    void addReturnReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
+        classMetadataFile.getReferences().addAll(
+                Stream.of(methodItem.getSyntax().getReturnValue())
+                        .filter(Objects::nonNull)
+                        .map(returnValue -> buildRefItem(returnValue.getReturnType()))
+                        .filter(o -> !classMetadataFile.getItems().contains(o))
+                        .collect(Collectors.toList()));
+    }
+
+    void addExceptionReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
+        classMetadataFile.getReferences().addAll(
+                methodItem.getExceptions().stream()
+                        .map(exceptionItem -> buildRefItem(exceptionItem.getType()))
+                        .filter(o -> !classMetadataFile.getItems().contains(o))
+                        .collect(Collectors.toList()));
+    }
+
+    void addTypeParameterReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
+        classMetadataFile.getReferences().addAll(
+                methodItem.getSyntax().getTypeParameters().stream()
+                        .map(typeParameter -> {
+                            String id = typeParameter.getId();
+                            return new MetadataFileItem(id, id, false);
+                        }).collect(Collectors.toList()));
+    }
+
+    void addSuperclassAndInterfacesReferences(TypeElement classElement, MetadataFile classMetadataFile) {
+        classMetadataFile.getReferences().addAll(classLookup.extractReferences(classElement));
+    }
+
+    void addInnerClassesReferences(TypeElement classElement, MetadataFile classMetadataFile) {
+        classMetadataFile.getReferences().addAll(
+                ElementFilter.typesIn(elementUtil.extractSortedElements(classElement)).stream()
+                        .map(this::buildClassReference)
+                        .collect(Collectors.toList()));
+    }
+
+    void addOverloadReferences(MetadataFileItem item, MetadataFile classMetadataFile) {
+        classMetadataFile.getReferences().add(new MetadataFileItem(item.getOverload()) {{
+            setName(RegExUtils.removeAll(item.getName(), "\\(.*\\)$"));
+            setNameWithType(RegExUtils.removeAll(item.getNameWithType(), "\\(.*\\)$"));
+            setFullName(RegExUtils.removeAll(item.getFullName(), "\\(.*\\)$"));
+            setPackageName(item.getPackageName());
+        }});
+    }
+
+    /**
+     * Replace one record in 'references' with several records in this way:
+     * <pre>
+     * a.b.c.List<df.mn.ClassOne<tr.T>> ->
+     *     - a.b.c.List
+     *     - df.mn.ClassOne
+     *     - tr.T
+     * </pre>
+     */
+    void expandComplexGenericsInReferences(MetadataFile classMetadataFile) {
+        Set<MetadataFileItem> additionalItems = new LinkedHashSet<>();
+        Iterator<MetadataFileItem> iterator = classMetadataFile.getReferences().iterator();
+        while (iterator.hasNext()) {
+            MetadataFileItem item = iterator.next();
+            String uid = item.getUid();
+            if (!uid.endsWith("*") && uid.contains("<")) {
+                List<String> classNames = splitUidWithGenericsIntoClassNames(uid);
+                additionalItems.addAll(classNames.stream()
+                        .map(s -> new MetadataFileItem(s, classLookup.makeTypeShort(s), false))
+                        .collect(Collectors.toSet()));
+            }
+        }
+        // Remove items which already exist in 'items' section (compared by 'uid' field)
+        additionalItems.removeAll(classMetadataFile.getItems());
+
+        classMetadataFile.getReferences().addAll(additionalItems);
+    }
+
+    MetadataFileItem buildRefItem(String uid) {
+        if (!uid.endsWith("*") && (uid.contains("<") || uid.contains("[]"))) {
+            return new MetadataFileItem(uid, getJavaSpec(replaceUidAndSplit(uid)));
+        } else {
+            List<String> fullNameList = new ArrayList<>();
+
+            environment.getIncludedElements().forEach(
+                    element -> elementUtil.extractSortedElements(element).forEach(
+                            typeElement -> fullNameList.add(classLookup.extractFullName(typeElement)))
+            );
+
+            if (fullNameList.contains(uid)) {
+                return new MetadataFileItem(uid, classLookup.makeTypeShort(uid), false);
+            } else {
+                return new MetadataFileItem(uid, getJavaSpec(replaceUidAndSplit(uid)));
+            }
+        }
+    }
+}

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
@@ -1,51 +1,34 @@
 package com.microsoft.build;
 
-import com.microsoft.lookup.BaseLookup;
 import com.microsoft.lookup.ClassItemsLookup;
 import com.microsoft.lookup.ClassLookup;
 import com.microsoft.lookup.PackageLookup;
-import com.microsoft.model.*;
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+import com.microsoft.model.TocFile;
+import com.microsoft.model.TocItem;
+import com.microsoft.model.TocTypeMap;
 import com.microsoft.util.ElementUtil;
 import com.microsoft.util.FileUtil;
-import com.microsoft.util.Utils;
-import com.microsoft.util.YamlUtil;
 import jdk.javadoc.doclet.DocletEnvironment;
-import org.apache.commons.lang3.RegExUtils;
-import org.apache.commons.lang3.StringUtils;
 
-import javax.lang.model.element.*;
-import javax.lang.model.util.ElementFilter;
-import java.util.*;
-import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import javax.lang.model.element.PackageElement;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static com.microsoft.build.BuilderUtil.populateUidValues;
 
 public class YmlFilesBuilder {
-
-    private final static String[] LANGS = {"java"};
-    private final Pattern XREF_LINK_PATTERN = Pattern.compile("<xref uid=\".*?\" .*?>.*?</xref>");
-    private final Pattern XREF_LINK_CONTENT_PATTERN = Pattern.compile("(?<=<xref uid=\").*?(?=\" .*?>.*?</xref>)");
-    private final Pattern XREF_LINK_RESOLVE_PATTERN = Pattern.compile("(?<class>\\w+)\\#(?<member>\\w+)(\\((?<param>.*)\\))?");
-
     private DocletEnvironment environment;
     private String outputPath;
     private ElementUtil elementUtil;
     private PackageLookup packageLookup;
-    private ClassItemsLookup classItemsLookup;
-    private ClassLookup classLookup;
     private String projectName;
-
-    private final Pattern JAVA_PATTERN = Pattern.compile("^java.*");
-    private final Pattern PROTOBUF_PATTERN = Pattern.compile("^com.google.protobuf.*");
-    private final Pattern GAX_PATTERN = Pattern.compile("^com.google.api.gax.*");
-    private final Pattern APICOMMON_PATTERN = Pattern.compile("^com.google.api.core.*");
-    private final Pattern LONGRUNNING_PATTERN = Pattern.compile("^com.google.longrunning.*");
-    private final Pattern ENDING_PATTERN = Pattern.compile(".*<\\?>$");
-    private final String PRIMITIVE_URL = "https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html";
-    private final String JAVA_BASE_URL = "https://docs.oracle.com/javase/8/docs/api/";
+    private ProjectBuilder projectBuilder;
+    private PackageBuilder packageBuilder;
+    private ClassBuilder classBuilder;
+    private ReferenceBuilder referenceBuilder;
 
     public YmlFilesBuilder(DocletEnvironment environment, String outputPath,
                            String[] excludePackages, String[] excludeClasses, String projectName) {
@@ -53,30 +36,41 @@ public class YmlFilesBuilder {
         this.outputPath = outputPath;
         this.elementUtil = new ElementUtil(excludePackages, excludeClasses);
         this.packageLookup = new PackageLookup(environment);
-        this.classItemsLookup = new ClassItemsLookup(environment);
-        this.classLookup = new ClassLookup(environment);
         this.projectName = projectName;
+        this.projectBuilder = new ProjectBuilder(projectName);
+        ClassLookup classLookup = new ClassLookup(environment);
+        this.referenceBuilder = new ReferenceBuilder(environment, classLookup, elementUtil);
+        this.packageBuilder = new PackageBuilder(packageLookup, outputPath, referenceBuilder);
+        this.classBuilder = new ClassBuilder(elementUtil, classLookup, new ClassItemsLookup(environment), outputPath, referenceBuilder);
     }
 
     public boolean build() {
-        MetadataFile projectMetadataFile = new MetadataFile(outputPath,"overview.yml");;
-        List<MetadataFileItem> packageItems = new ArrayList<>();
+        //  table of contents
+        TocFile tocFile = new TocFile(outputPath, projectName);
+        //  overview page
+        MetadataFile projectMetadataFile = new MetadataFile(outputPath, "overview.yml");
+        //  package summary pages
         List<MetadataFile> packageMetadataFiles = new ArrayList<>();
+        //  packages
+        List<MetadataFileItem> packageItems = new ArrayList<>();
+        //  class/enum/interface/etc. pages
         List<MetadataFile> classMetadataFiles = new ArrayList<>();
 
-        TocFile tocFile = new TocFile(outputPath, projectName);
-        for (PackageElement packageElement : elementUtil.extractPackageElements(environment.getIncludedElements())) {
-            String uid = packageLookup.extractUid(packageElement);
-            String status = packageLookup.extractStatus(packageElement.getQualifiedName().toString());
-            TocItem packageTocItem = new TocItem(uid, uid, status);
-            packageMetadataFiles.add(buildPackageMetadataFile(packageElement));
-            packageTocItem.getItems().add(new TocItem(uid, "Package summary"));
-
-            TocTypeMap typeMap = new TocTypeMap();
-            buildFilesForInnerClasses(packageElement,typeMap, classMetadataFiles);
-            packageTocItem.getItems().addAll(joinTocTypeItems(typeMap));
-
+        for (PackageElement packageElement :
+                elementUtil.extractPackageElements(environment.getIncludedElements())) {
+            String packageUid = packageLookup.extractUid(packageElement);
+            String packageStatus = packageLookup.extractStatus(packageElement.getQualifiedName().toString());
+            TocItem packageTocItem = new TocItem(packageUid, packageUid, packageStatus);
+            //  build package summary
+            packageMetadataFiles.add(packageBuilder.buildPackageMetadataFile(packageElement));
+            // add package summary to toc
+            packageTocItem.getItems().add(new TocItem(packageUid, "Package summary"));
             tocFile.addTocItem(packageTocItem);
+
+            // build classes/interfaces/enums/exceptions/annotations
+            TocTypeMap typeMap = new TocTypeMap();
+            classBuilder.buildFilesForInnerClasses(packageElement, typeMap, classMetadataFiles);
+            packageTocItem.getItems().addAll(joinTocTypeItems(typeMap));
         }
 
         for (MetadataFile packageFile : packageMetadataFiles) {
@@ -91,10 +85,14 @@ public class YmlFilesBuilder {
                 }
             }
         }
-        buildProjectMetadataFile(packageItems, projectMetadataFile);
-        populateUidValues(packageMetadataFiles, classMetadataFiles);
-        updateExternalReferences(classMetadataFiles);
+        // build project summary page
+        projectBuilder.buildProjectMetadataFile(packageItems, projectMetadataFile);
 
+        // post-processing
+        populateUidValues(packageMetadataFiles, classMetadataFiles);
+        referenceBuilder.updateExternalReferences(classMetadataFiles);
+
+        //  write to yaml files
         FileUtil.dumpToFile(projectMetadataFile);
         packageMetadataFiles.forEach(FileUtil::dumpToFile);
         classMetadataFiles.forEach(FileUtil::dumpToFile);
@@ -103,582 +101,12 @@ public class YmlFilesBuilder {
         return true;
     }
 
-    List<TocItem> joinTocTypeItems(TocTypeMap tocTypeMap){
+    List<TocItem> joinTocTypeItems(TocTypeMap tocTypeMap) {
         return tocTypeMap.getTitleList().stream()
                 .filter(kindTitle -> tocTypeMap.get(kindTitle.getElementKind()).size() > 0)
                 .flatMap(kindTitle -> {
                     tocTypeMap.get(kindTitle.getElementKind()).add(0, new TocItem(kindTitle.getTitle()));
                     return tocTypeMap.get(kindTitle.getElementKind()).stream();
                 }).collect(Collectors.toList());
-    }
-
-    void buildFilesForInnerClasses(Element element, TocTypeMap tocTypeMap, List<MetadataFile> container) {
-        for (TypeElement classElement : elementUtil.extractSortedElements(element)) {
-            String uid = classLookup.extractUid(classElement);
-            String name = classLookup.extractTocName(classElement);
-            String status = classLookup.extractStatus(classElement);
-
-            if (tocTypeMap.get(classElement.getKind().name()) != null) {
-                if (classElement.getKind().name().equals(ElementKind.CLASS.name()) && name.contains("Exception")) {
-                    tocTypeMap.get("EXCEPTION").add(new TocItem(uid, name, status));
-                } else {
-                    tocTypeMap.get(classElement.getKind().name()).add(new TocItem(uid, name, status));
-                }
-            } else {
-                tocTypeMap.get(ElementKind.CLASS.name()).add(new TocItem(uid, name, status));
-            }
-
-            container.add(buildClassYmlFile(classElement));
-            buildFilesForInnerClasses(classElement, tocTypeMap, container);
-        }
-    }
-
-
-    void buildProjectMetadataFile(List<MetadataFileItem> packageItems, MetadataFile projectMetadataFile) {
-        MetadataFileItem projectItem = new MetadataFileItem(LANGS, projectName);
-        projectItem.setNameWithType(projectName);
-        projectItem.setFullName(projectName);
-        projectItem.setType("Namespace");
-        projectItem.setJavaType("overview");
-
-        List<String> children = new ArrayList<>();
-        List<MetadataFileItem> references = new ArrayList<>();
-        packageItems.stream().forEach(i ->  {
-            children.add(i.getUid());
-            MetadataFileItem refItem = new MetadataFileItem(i.getUid());
-            refItem.setName(i.getName());
-            refItem.setNameWithType(i.getNameWithType());
-            refItem.setFullName(i.getFullName());
-            references.add(refItem);
-        });
-
-        projectItem.getChildren().addAll(children);
-        projectMetadataFile.getReferences().addAll(references);
-        projectMetadataFile.getItems().add(projectItem);
-    }
-
-    MetadataFile buildPackageMetadataFile(PackageElement packageElement) {
-        String fileName = packageLookup.extractHref(packageElement);
-        MetadataFile packageMetadataFile = new MetadataFile(outputPath, fileName);
-        MetadataFileItem packageItem = new MetadataFileItem(LANGS, packageLookup.extractUid(packageElement));
-        packageItem.setId(packageLookup.extractId(packageElement));
-        addChildrenReferences(packageElement, packageItem.getChildren(), packageMetadataFile.getReferences());
-        populateItemFields(packageItem, packageLookup, packageElement);
-        packageMetadataFile.getItems().add(packageItem);
-        return packageMetadataFile;
-    }
-
-    void addChildrenReferences(Element element, List<String> packageChildren,
-                               Set<MetadataFileItem> referencesCollector) {
-        for (TypeElement classElement : elementUtil.extractSortedElements(element)) {
-            referencesCollector.add(buildClassReference(classElement));
-
-            packageChildren.add(classLookup.extractUid(classElement));
-            addChildrenReferences(classElement, packageChildren, referencesCollector);
-        }
-    }
-
-    MetadataFileItem buildClassReference(TypeElement classElement) {
-        MetadataFileItem referenceItem = new MetadataFileItem(classLookup.extractUid(classElement));
-        referenceItem.setName(classLookup.extractName(classElement));
-        referenceItem.setNameWithType(classLookup.extractNameWithType(classElement));
-        referenceItem.setFullName(classLookup.extractFullName(classElement));
-        return referenceItem;
-    }
-
-    <T extends Element> void populateItemFields(MetadataFileItem item, BaseLookup<T> lookup, T element) {
-        String name = lookup.extractName(element);
-        item.setName(name);
-        item.setNameWithType(lookup.extractNameWithType(element));
-        item.setFullName(lookup.extractFullName(element));
-        item.setType(lookup.extractType(element));
-        item.setJavaType(lookup.extractJavaType(element));
-        item.setSummary(lookup.extractSummary(element));
-        item.setContent(lookup.extractContent(element));
-    }
-
-    MetadataFile buildClassYmlFile(TypeElement classElement) {
-        String fileName = classLookup.extractHref(classElement);
-        MetadataFile classMetadataFile = new MetadataFile(outputPath, fileName);
-        addClassInfo(classElement, classMetadataFile);
-        addConstructorsInfo(classElement, classMetadataFile);
-        addMethodsInfo(classElement, classMetadataFile);
-        addFieldsInfo(classElement, classMetadataFile);
-        addReferencesInfo(classElement, classMetadataFile);
-        applyPostProcessing(classMetadataFile);
-        return classMetadataFile;
-    }
-
-    void addClassInfo(TypeElement classElement, MetadataFile classMetadataFile) {
-        MetadataFileItem classItem = new MetadataFileItem(LANGS, classLookup.extractUid(classElement));
-        classItem.setId(classLookup.extractId(classElement));
-        classItem.setParent(classLookup.extractParent(classElement));
-        addChildren(classElement, classItem.getChildren());
-        populateItemFields(classItem, classLookup, classElement);
-        classItem.setPackageName(classLookup.extractPackageName(classElement));
-        classItem.setTypeParameters(classLookup.extractTypeParameters(classElement));
-        classItem.setInheritance(classLookup.extractSuperclass(classElement));
-        classItem.setInterfaces(classLookup.extractInterfaces(classElement));
-        classItem.setInheritedMethods(classLookup.extractInheritedMethods(classElement));
-        String depMsg = classLookup.extractDeprecatedDescription(classElement);
-        if (depMsg != null) {
-            classItem.setSummary(getDeprecatedSummary(depMsg, classItem.getSummary()));
-            classItem.setStatus(Status.DEPRECATED.toString());
-        }
-        classMetadataFile.getItems().add(classItem);
-    }
-
-    String getDeprecatedSummary(String depMsg, String summary){
-        String result = "<p>(deprecated) " + depMsg + "</p>";
-        if (summary != null && !summary.equals("")) {
-            result = result + "\n" + summary;
-        }
-        return  result;
-    }
-
-    void addChildren(TypeElement classElement, List<String> children) {
-        collect(classElement, children, ElementFilter::constructorsIn, classItemsLookup::extractUid);
-        collect(classElement, children, ElementFilter::methodsIn, classItemsLookup::extractUid);
-        collect(classElement, children, ElementFilter::fieldsIn, classItemsLookup::extractUid);
-        collect(classElement, children, ElementFilter::typesIn, String::valueOf);
-    }
-
-    List<? extends Element> filterPrivateElements(List<? extends Element> elements) {
-        return elements.stream()
-                .filter(element -> !Utils.isPrivateOrPackagePrivate(element)).collect(Collectors.toList());
-    }
-
-    void collect(TypeElement classElement, List<String> children,
-                 Function<Iterable<? extends Element>, List<? extends Element>> selectFunc,
-                 Function<? super Element, String> mapFunc) {
-
-        List<? extends Element> elements = selectFunc.apply(classElement.getEnclosedElements());
-        children.addAll(filterPrivateElements(elements).stream()
-                .map(mapFunc).collect(Collectors.toList()));
-    }
-
-    void addConstructorsInfo(TypeElement classElement, MetadataFile classMetadataFile) {
-        for (ExecutableElement constructorElement : ElementFilter.constructorsIn(classElement.getEnclosedElements())) {
-            MetadataFileItem constructorItem = buildMetadataFileItem(constructorElement);
-            constructorItem.setOverload(classItemsLookup.extractOverload(constructorElement));
-            constructorItem.setContent(classItemsLookup.extractConstructorContent(constructorElement));
-            constructorItem.setParameters(classItemsLookup.extractParameters(constructorElement));
-            String depMsg = classItemsLookup.extractDeprecatedDescription(constructorElement);
-            if (depMsg != null) {
-                constructorItem.setSummary(getDeprecatedSummary(depMsg, constructorItem.getSummary()));
-                constructorItem.setStatus(Status.DEPRECATED.toString());
-            }
-            classMetadataFile.getItems().add(constructorItem);
-
-            addParameterReferences(constructorItem, classMetadataFile);
-            addOverloadReferences(constructorItem, classMetadataFile);
-        }
-    }
-
-    void addMethodsInfo(TypeElement classElement, MetadataFile classMetadataFile) {
-        ElementFilter.methodsIn(classElement.getEnclosedElements()).stream()
-                .filter(methodElement -> !Utils.isPrivateOrPackagePrivate(methodElement))
-                .forEach(methodElement -> {
-                    MetadataFileItem methodItem = buildMetadataFileItem(methodElement);
-                    methodItem.setOverload(classItemsLookup.extractOverload(methodElement));
-                    methodItem.setContent(classItemsLookup.extractMethodContent(methodElement));
-                    methodItem.setExceptions(classItemsLookup.extractExceptions(methodElement));
-                    methodItem.setParameters(classItemsLookup.extractParameters(methodElement));
-                    methodItem.setReturn(classItemsLookup.extractReturn(methodElement));
-                    methodItem.setOverridden(classItemsLookup.extractOverridden(methodElement));
-                    String depMsg = classItemsLookup.extractDeprecatedDescription(methodElement);
-                    if (depMsg != null) {
-                        methodItem.setSummary(getDeprecatedSummary(depMsg, methodItem.getSummary()));
-                        methodItem.setStatus(Status.DEPRECATED.toString());
-                    }
-
-                    classMetadataFile.getItems().add(methodItem);
-                    addExceptionReferences(methodItem, classMetadataFile);
-                    addParameterReferences(methodItem, classMetadataFile);
-                    addReturnReferences(methodItem, classMetadataFile);
-                    addOverloadReferences(methodItem, classMetadataFile);
-                });
-    }
-
-    void addFieldsInfo(TypeElement classElement, MetadataFile classMetadataFile) {
-        ElementFilter.fieldsIn(classElement.getEnclosedElements()).stream()
-                .filter(fieldElement -> !Utils.isPrivateOrPackagePrivate(fieldElement))
-                .forEach(fieldElement -> {
-                    MetadataFileItem fieldItem = buildMetadataFileItem(fieldElement);
-                    fieldItem.setContent(classItemsLookup.extractFieldContent(fieldElement));
-                    fieldItem.setReturn(classItemsLookup.extractReturn(fieldElement));
-                    String depMsg = classItemsLookup.extractDeprecatedDescription(fieldElement);
-                    if (depMsg != null) {
-                        fieldItem.setSummary(getDeprecatedSummary(depMsg, fieldItem.getSummary()));
-                        fieldItem.setStatus(Status.DEPRECATED.toString());
-                    }
-
-                    classMetadataFile.getItems().add(fieldItem);
-                    addReturnReferences(fieldItem, classMetadataFile);
-                });
-    }
-
-    void addReferencesInfo(TypeElement classElement, MetadataFile classMetadataFile) {
-        MetadataFileItem classReference = new MetadataFileItem(classLookup.extractUid(classElement));
-        classReference.setParent(classLookup.extractParent(classElement));
-        populateItemFields(classReference, classLookup, classElement);
-        classReference.setTypeParameters(classLookup.extractTypeParameters(classElement));
-
-        addTypeParameterReferences(classReference, classMetadataFile);
-        addSuperclassAndInterfacesReferences(classElement, classMetadataFile);
-        addInnerClassesReferences(classElement, classMetadataFile);
-    }
-
-    MetadataFileItem buildMetadataFileItem(Element element) {
-        return new MetadataFileItem(LANGS, classItemsLookup.extractUid(element)) {{
-            String name = classItemsLookup.extractName(element);
-            setId(classItemsLookup.extractId(element));
-            setParent(classItemsLookup.extractParent(element));
-            setName(name);
-            setNameWithType(classItemsLookup.extractNameWithType(element));
-            setFullName(classItemsLookup.extractFullName(element));
-            setType(classItemsLookup.extractType(element));
-            setJavaType(classItemsLookup.extractJavaType(element));
-            setPackageName(classItemsLookup.extractPackageName(element));
-            setSummary(classItemsLookup.extractSummary(element));
-        }};
-    }
-
-    protected String getJavaReferenceHref(String uid) {
-        if (uid == null || uid.equals("")) {
-            return JAVA_BASE_URL;
-        }
-        //  example1 uid: "java.lang.Object.equals(java.lang.Object)"
-        //  example2 uid: "java.lang.Object"
-        String endURL = uid.replaceAll("<T>", "");
-
-        Pattern argPattern = Pattern.compile(".*\\(.*\\).*");
-        if (argPattern.matcher(endURL).find()) {
-            // example1
-            // argumentSplit: ["java.lang.Object.equals", "java.lang.Object)"]
-            // nameSplit: ["java", "lang", "Object", "equals"]
-            List<String> argumentSplit = Arrays.asList(endURL.split("\\("));
-            List<String> nameSplit = Arrays.asList(argumentSplit.get(0).split("\\."));
-
-            // className: "java/lang/Object"
-            // methodName: "#equals"
-            // argumentsName: "#java.lang.Object-"
-            String className = String.join("/", nameSplit.subList(0, nameSplit.size() - 1));
-            String methodName = "#" + nameSplit.get(nameSplit.size() - 1);
-            String argumentsName = argumentSplit.get(1).replaceAll("[,)]", "-");
-
-            // endURL: "java/lang/Object.html#equals-java.lang.Object-"
-            endURL = className + ".html" + methodName + "-" + argumentsName;
-        } else {
-            // example2
-            // endURL = java/lang/Object.html
-            endURL = endURL.replaceAll("\\.", "/");
-            endURL = endURL + ".html";
-        }
-        return JAVA_BASE_URL + endURL;
-    }
-
-    private void updateExternalReferences(List<MetadataFile> classMetadataFiles) {
-        classMetadataFiles.forEach(file -> file.getReferences()
-                .forEach(ref -> updateExternalReference(ref)));
-    }
-
-    private void updateExternalReference(MetadataFileItem reference) {
-        String uid = reference.getUid();
-        uid = updateReferenceUid(uid);
-
-        if (isJavaPrimitive(uid)) {
-            reference.setHref(PRIMITIVE_URL);
-            return;
-        }
-        if (isJavaLibrary(uid)) {
-            reference.setHref(getJavaReferenceHref(uid));
-        }
-        if (isExternalReference(uid)) {
-            reference.setIsExternal(true);
-        }
-        if (reference.getSpecForJava().size() > 0) {
-            for (SpecViewModel spec : reference.getSpecForJava()) {
-                String specUid = spec.getUid();
-                if (specUid != null) {
-                    if (isJavaPrimitive(specUid)) {
-                        spec.setHref(PRIMITIVE_URL);
-                    }
-                    if (isJavaLibrary(specUid)) {
-                        spec.setHref(getJavaReferenceHref(specUid));
-                    }
-                    if (isExternalReference(specUid)) {
-                        spec.setIsExternal(true);
-                    }
-                }
-            }
-        }
-    }
-
-    private String updateReferenceUid(String uid) {
-        if (ENDING_PATTERN.matcher(uid).find()) {
-            uid = uid.replace("<?>", "");
-        }
-        return uid;
-    }
-
-    private boolean isExternalReference(String uid) {
-        return (PROTOBUF_PATTERN.matcher(uid).find() || GAX_PATTERN.matcher(uid).find() || APICOMMON_PATTERN.matcher(uid).find() || GAX_PATTERN.matcher(uid).find() || LONGRUNNING_PATTERN.matcher(uid).find());
-    }
-
-    private boolean isJavaPrimitive(String uid) {
-        return (uid.equals("boolean") || uid.equals("int") || uid.equals("byte") || uid.equals("long") || uid.equals("float") || uid.equals("double") || uid.equals("char") || uid.equals("short"));
-    }
-
-    private boolean isJavaLibrary(String uid) {
-        return JAVA_PATTERN.matcher(uid).find();
-    }
-
-    void addParameterReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
-        classMetadataFile.getReferences().addAll(
-                methodItem.getSyntax().getParameters().stream()
-                        .map(parameter -> buildRefItem(parameter.getType()))
-                        .filter(o -> !classMetadataFile.getItems().contains(o))
-                        .collect(Collectors.toList()));
-    }
-
-    void addReturnReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
-        classMetadataFile.getReferences().addAll(
-                Stream.of(methodItem.getSyntax().getReturnValue())
-                        .filter(Objects::nonNull)
-                        .map(returnValue -> buildRefItem(returnValue.getReturnType()))
-                        .filter(o -> !classMetadataFile.getItems().contains(o))
-                        .collect(Collectors.toList()));
-    }
-
-    void addExceptionReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
-        classMetadataFile.getReferences().addAll(
-                methodItem.getExceptions().stream()
-                        .map(exceptionItem -> buildRefItem(exceptionItem.getType()))
-                        .filter(o -> !classMetadataFile.getItems().contains(o))
-                        .collect(Collectors.toList()));
-    }
-
-    void addTypeParameterReferences(MetadataFileItem methodItem, MetadataFile classMetadataFile) {
-        classMetadataFile.getReferences().addAll(
-                methodItem.getSyntax().getTypeParameters().stream()
-                        .map(typeParameter -> {
-                            String id = typeParameter.getId();
-                            return new MetadataFileItem(id, id, false);
-                        }).collect(Collectors.toList()));
-    }
-
-    void addSuperclassAndInterfacesReferences(TypeElement classElement, MetadataFile classMetadataFile) {
-        classMetadataFile.getReferences().addAll(classLookup.extractReferences(classElement));
-    }
-
-    void addInnerClassesReferences(TypeElement classElement, MetadataFile classMetadataFile) {
-        classMetadataFile.getReferences().addAll(
-                ElementFilter.typesIn(elementUtil.extractSortedElements(classElement)).stream()
-                        .map(this::buildClassReference)
-                        .collect(Collectors.toList()));
-    }
-
-    void addOverloadReferences(MetadataFileItem item, MetadataFile classMetadataFile) {
-        classMetadataFile.getReferences().add(new MetadataFileItem(item.getOverload()) {{
-            setName(RegExUtils.removeAll(item.getName(), "\\(.*\\)$"));
-            setNameWithType(RegExUtils.removeAll(item.getNameWithType(), "\\(.*\\)$"));
-            setFullName(RegExUtils.removeAll(item.getFullName(), "\\(.*\\)$"));
-            setPackageName(item.getPackageName());
-        }});
-    }
-
-    void applyPostProcessing(MetadataFile classMetadataFile) {
-        expandComplexGenericsInReferences(classMetadataFile);
-    }
-
-    /**
-     * Replace one record in 'references' with several records in this way:
-     * <pre>
-     * a.b.c.List<df.mn.ClassOne<tr.T>> ->
-     *     - a.b.c.List
-     *     - df.mn.ClassOne
-     *     - tr.T
-     * </pre>
-     */
-    void expandComplexGenericsInReferences(MetadataFile classMetadataFile) {
-        Set<MetadataFileItem> additionalItems = new LinkedHashSet<>();
-        Iterator<MetadataFileItem> iterator = classMetadataFile.getReferences().iterator();
-        while (iterator.hasNext()) {
-            MetadataFileItem item = iterator.next();
-            String uid = item.getUid();
-            if (!uid.endsWith("*") && uid.contains("<")) {
-                List<String> classNames = splitUidWithGenericsIntoClassNames(uid);
-                additionalItems.addAll(classNames.stream()
-                        .map(s -> new MetadataFileItem(s, classLookup.makeTypeShort(s), false))
-                        .collect(Collectors.toSet()));
-            }
-        }
-        // Remove items which already exist in 'items' section (compared by 'uid' field)
-        additionalItems.removeAll(classMetadataFile.getItems());
-
-        classMetadataFile.getReferences().addAll(additionalItems);
-    }
-
-    void populateUidValues(List<MetadataFile> packageMetadataFiles, List<MetadataFile> classMetadataFiles) {
-        Lookup lookup = new Lookup(packageMetadataFiles, classMetadataFiles);
-
-        classMetadataFiles.forEach(classMetadataFile -> {
-            LookupContext lookupContext = lookup.buildContext(classMetadataFile);
-
-            for (MetadataFileItem item : classMetadataFile.getItems()) {
-                item.setSummary(YamlUtil.cleanupHtml(
-                        populateUidValues(item.getSummary(), lookupContext)
-                ));
-
-                Optional.ofNullable(item.getSyntax()).ifPresent(syntax -> {
-                            Optional.ofNullable(syntax.getParameters()).ifPresent(
-                                    methodParams -> methodParams.forEach(
-                                            param -> {
-                                                param.setDescription(populateUidValues(param.getDescription(), lookupContext));
-                                            })
-                            );
-                            Optional.ofNullable(syntax.getReturnValue()).ifPresent(returnValue ->
-                                    returnValue.setReturnDescription(
-                                            populateUidValues(syntax.getReturnValue().getReturnDescription(), lookupContext)
-                                    )
-                            );
-                        }
-                );
-            }
-        });
-    }
-
-    String populateUidValues(String text, LookupContext lookupContext) {
-        if (StringUtils.isBlank(text)) {
-            return text;
-        }
-
-        Matcher linkMatcher = XREF_LINK_PATTERN.matcher(text);
-        while (linkMatcher.find()) {
-            String link = linkMatcher.group();
-            Matcher linkContentMatcher = XREF_LINK_CONTENT_PATTERN.matcher(link);
-            if (!linkContentMatcher.find()) {
-                continue;
-            }
-
-            String linkContent = linkContentMatcher.group();
-            String uid = resolveUidFromLinkContent(linkContent, lookupContext);
-            String updatedLink = linkContentMatcher.replaceAll(uid);
-            text = StringUtils.replace(text, link, updatedLink);
-        }
-        return text;
-    }
-
-    /**
-     * The linkContent could be in following format
-     * #memeber
-     * Class#member
-     * Class#method()
-     * Class#method(params)
-     */
-    String resolveUidFromLinkContent(String linkContent, LookupContext lookupContext) {
-        if (StringUtils.isBlank(linkContent)) {
-            return "";
-        }
-
-        linkContent = linkContent.trim();
-
-        // complete class name for class internal link
-        if (linkContent.startsWith("#")) {
-            String firstKey = lookupContext.getOwnerUid();
-            linkContent = firstKey + linkContent;
-        }
-
-        // fuzzy resolve, target for items from project external references
-        String fuzzyResolvedUid = resolveUidFromReference(linkContent, lookupContext);
-
-        // exact resolve in lookupContext
-        linkContent = linkContent.replace("#", ".");
-        String exactResolveUid = resolveUidByLookup(linkContent, lookupContext);
-        return exactResolveUid.isEmpty() ? fuzzyResolvedUid : exactResolveUid;
-    }
-
-    List<String> splitUidWithGenericsIntoClassNames(String uid) {
-        uid = RegExUtils.removeAll(uid, "[>]+$");
-        return Arrays.asList(StringUtils.split(uid, "<"));
-    }
-
-    MetadataFileItem buildRefItem(String uid) {
-        if (!uid.endsWith("*") && (uid.contains("<") || uid.contains("[]"))) {
-            return new MetadataFileItem(uid, getJavaSpec(replaceUidAndSplit(uid)));
-        } else {
-            List<String> fullNameList = new ArrayList<>();
-
-            this.environment.getIncludedElements().forEach(
-                    element -> elementUtil.extractSortedElements(element).forEach(
-                            typeElement -> fullNameList.add(classLookup.extractFullName(typeElement)))
-            );
-
-            if (fullNameList.contains(uid)) {
-                return new MetadataFileItem(uid, classLookup.makeTypeShort(uid), false);
-            } else {
-                return new MetadataFileItem(uid, getJavaSpec(replaceUidAndSplit(uid)));
-            }
-        }
-    }
-
-    List<String> replaceUidAndSplit(String uid) {
-        String retValue = RegExUtils.replaceAll(uid, "\\<", "//<//");
-        retValue = RegExUtils.replaceAll(retValue, "\\>", "//>//");
-        retValue = RegExUtils.replaceAll(retValue, ",", "//,//");
-        retValue = RegExUtils.replaceAll(retValue, "\\[\\]", "//[]//");
-
-        return Arrays.asList(StringUtils.split(retValue, "//"));
-    }
-
-    List<SpecViewModel> getJavaSpec(List<String> references) {
-        List<SpecViewModel> specList = new ArrayList<>();
-
-        Optional.ofNullable(references).ifPresent(
-                ref -> references.forEach(
-                        uid -> {
-                            if (uid.equalsIgnoreCase("<")
-                                    || uid.equalsIgnoreCase(">")
-                                    || uid.equalsIgnoreCase(",")
-                                    || uid.equalsIgnoreCase("[]"))
-                                specList.add(new SpecViewModel(null, uid));
-                            else if (uid != "")
-                                specList.add(new SpecViewModel(uid, uid));
-                        })
-        );
-
-        return specList;
-    }
-
-    /**
-     * this method is used to do fuzzy resolve
-     * "*" will be added at the end of uid for method for xerf service resolve purpose
-     */
-    String resolveUidFromReference(String linkContent, LookupContext lookupContext) {
-        String uid = "";
-        Matcher matcher = XREF_LINK_RESOLVE_PATTERN.matcher(linkContent);
-
-        if (matcher.find()) {
-            String className = matcher.group("class");
-            String memberName = matcher.group("member");
-            uid = resolveUidByLookup(className, lookupContext);
-            if (!uid.isEmpty()) {
-                uid = uid.concat(".").concat(memberName);
-
-                // linkContent targets a method
-                if (!StringUtils.isBlank(matcher.group(3))) {
-                    uid = uid.concat("*");
-                }
-            }
-        }
-        return uid;
-    }
-
-    String resolveUidByLookup(String signature, LookupContext lookupContext) {
-        if (StringUtils.isBlank(signature) || lookupContext == null) {
-            return "";
-        }
-        return lookupContext.containsKey(signature) ? lookupContext.resolve(signature) : "";
     }
 }

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/BuilderUtilTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/BuilderUtilTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+import com.microsoft.model.MethodParameter;
+import com.microsoft.model.Syntax;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BuilderUtilTest {
+    @Test
+    public void populateUidValues() {
+        MetadataFile classMetadataFile = new MetadataFile("output", "name");
+
+        MetadataFileItem ownerClassItem = buildMetadataFileItem("a.b.OwnerClass", "Not important summary value");
+        ownerClassItem.setNameWithType("OwnerClass");
+        MetadataFileItem item1 = buildMetadataFileItem("UID unknown class", "UnknownClass");
+        populateSyntax(item1, "SomeClass#someMethod(String param)");
+        MetadataFileItem item2 = buildMetadataFileItem("UID known class", "SomeClass#someMethod(String param)");
+        MetadataFileItem item3 = buildMetadataFileItem("UID method only", "#someMethod2(String p1, String p2)");
+        classMetadataFile.getItems().addAll(Arrays.asList(ownerClassItem, item1, item2, item3));
+
+        MetadataFileItem reference1 = new MetadataFileItem("a.b.SomeClass.someMethod(String param)");
+        reference1.setNameWithType("SomeClass.someMethod(String param)");
+        MetadataFileItem reference2 = new MetadataFileItem("a.b.OwnerClass.someMethod2(String p1, String p2)");
+        reference2.setNameWithType("OwnerClass.someMethod2(String p1, String p2)");
+        classMetadataFile.getReferences().addAll(Arrays.asList(reference1, reference2));
+
+        BuilderUtil.populateUidValues(Collections.emptyList(), Arrays.asList(classMetadataFile));
+
+        assertEquals("Wrong summary for unknown class", item1.getSummary(),
+                "Bla bla <xref uid=\"\" data-throw-if-not-resolved=\"false\">UnknownClass</xref> bla");
+        assertEquals("Wrong syntax description", item1.getSyntax().getParameters().get(0).getDescription(),
+                "One two <xref uid=\"a.b.SomeClass.someMethod(String param)\" data-throw-if-not-resolved=\"false\">SomeClass#someMethod(String param)</xref> three");
+        assertEquals("Wrong summary for known class", item2.getSummary(),
+                "Bla bla <xref uid=\"a.b.SomeClass.someMethod(String param)\" data-throw-if-not-resolved=\"false\">SomeClass#someMethod(String param)</xref> bla");
+        assertEquals("Wrong summary for method", item3.getSummary(),
+                "Bla bla <xref uid=\"a.b.OwnerClass.someMethod2(String p1, String p2)\" data-throw-if-not-resolved=\"false\">#someMethod2(String p1, String p2)</xref> bla");
+
+    }
+
+    private MetadataFileItem buildMetadataFileItem(String uid, String value) {
+        MetadataFileItem item = new MetadataFileItem(uid);
+        item.setSummary(
+                String.format("Bla bla <xref uid=\"%s\" data-throw-if-not-resolved=\"false\">%s</xref> bla", value, value));
+        return item;
+    }
+
+    private void populateSyntax(MetadataFileItem item, String value) {
+        Syntax syntax = new Syntax();
+        String methodParamDescription = String
+                .format("One two <xref uid=\"%s\" data-throw-if-not-resolved=\"false\">%s</xref> three", value, value);
+        syntax.setParameters(
+                Arrays.asList(new MethodParameter("method param id", "method param type", methodParamDescription)));
+        item.setSyntax(syntax);
+    }
+
+    @Test
+    public void determineUidByLinkContent() {
+        Map<String, String> lookup = new HashMap<>() {{
+            put("SomeClass", "a.b.c.SomeClass");
+            put("SomeClass.someMethod()", "a.b.c.SomeClass.someMethod()");
+            put("SomeClass.someMethod(String param)", "a.b.c.SomeClass.someMethod(String param)");
+        }};
+
+        LookupContext lookupContext = new LookupContext(lookup, lookup);
+        assertEquals("Wrong result for class", BuilderUtil.
+                resolveUidByLookup("SomeClass", lookupContext), "a.b.c.SomeClass");
+        assertEquals("Wrong result for method", BuilderUtil.
+                resolveUidFromLinkContent("SomeClass#someMethod()", lookupContext), "a.b.c.SomeClass.someMethod()");
+        assertEquals("Wrong result for method with param", BuilderUtil.
+                        resolveUidFromLinkContent("SomeClass#someMethod(String param)", lookupContext),
+                "a.b.c.SomeClass.someMethod(String param)");
+
+        assertEquals("Wrong result for unknown class", BuilderUtil.
+                resolveUidByLookup("UnknownClass", lookupContext), "");
+        assertEquals("Wrong result for null", BuilderUtil.resolveUidByLookup(null, lookupContext), "");
+        assertEquals("Wrong result for whitespace", BuilderUtil.resolveUidByLookup(" ", lookupContext), "");
+    }
+
+    @Test
+    public void splitUidWithGenericsIntoClassNames() {
+        List<String> result = BuilderUtil.splitUidWithGenericsIntoClassNames("a.b.c.List<df.mn.ClassOne<tr.T>>");
+
+        assertEquals("Wrong result list size", result.size(), 3);
+        assertTrue("Wrong result list content", result.contains("a.b.c.List"));
+        assertTrue("Wrong result list content", result.contains("df.mn.ClassOne"));
+        assertTrue("Wrong result list content", result.contains("tr.T"));
+    }
+}

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/ClassBuilderTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/ClassBuilderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.google.testing.compile.CompilationRule;
+import com.microsoft.lookup.ClassItemsLookup;
+import com.microsoft.lookup.ClassLookup;
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+import com.microsoft.util.ElementUtil;
+import com.sun.source.util.DocTrees;
+import jdk.javadoc.doclet.DocletEnvironment;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import java.io.File;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class ClassBuilderTest {
+    @Rule
+    public CompilationRule rule = new CompilationRule();
+    private Elements elements;
+    private ClassBuilder classBuilder;
+    private DocletEnvironment environment;
+    private DocTrees docTrees;
+
+    @Before
+    public void setup() {
+        elements = rule.getElements();
+        environment = Mockito.mock(DocletEnvironment.class);
+        docTrees = Mockito.mock(DocTrees.class);
+        ElementUtil elementUtil = new ElementUtil(new String[0], new String[0]);
+        ClassLookup classLookup = new ClassLookup(environment);
+        classBuilder = new ClassBuilder(
+                elementUtil,
+                classLookup,
+                new ClassItemsLookup(environment),
+                "./target",
+                new ReferenceBuilder(environment, classLookup, elementUtil));
+    }
+    @Test
+    public void addConstructorsInfoWhenOnlyDefaultConstructor() {
+        TypeElement element = elements.getTypeElement("com.microsoft.samples.subpackage.Person");
+        MetadataFile container = new MetadataFile("output", "name");
+        when(environment.getElementUtils()).thenReturn(elements);
+        when(environment.getDocTrees()).thenReturn(docTrees);
+
+        classBuilder.addConstructorsInfo(element, container);
+
+        assertEquals("Wrong file name", container.getFileNameWithPath(), "output" + File.separator + "name");
+        assertEquals("Container should contain constructor item", container.getItems().size(), 1);
+    }
+
+    @Test
+    public void addConstructorsInfo() {
+        TypeElement element = elements.getTypeElement("com.microsoft.samples.SuperHero");
+        MetadataFile container = new MetadataFile("output", "name");
+        when(environment.getElementUtils()).thenReturn(elements);
+        when(environment.getDocTrees()).thenReturn(docTrees);
+
+        classBuilder.addConstructorsInfo(element, container);
+
+        assertEquals("Wrong file name", container.getFileNameWithPath(), "output" + File.separator + "name");
+        Collection<MetadataFileItem> constructorItems = container.getItems();
+        assertEquals("Container should contain 2 constructor items", constructorItems.size(), 2);
+    }
+}

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/ReferenceBuilderTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/ReferenceBuilderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.microsoft.build;
+
+import com.microsoft.lookup.ClassLookup;
+import com.microsoft.model.MetadataFile;
+import com.microsoft.model.MetadataFileItem;
+import com.microsoft.util.ElementUtil;
+import jdk.javadoc.doclet.DocletEnvironment;
+import org.apache.commons.lang3.RegExUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ReferenceBuilderTest {
+
+    private ReferenceBuilder referenceBuilder;
+
+    @Before
+    public void setup() {
+        DocletEnvironment environment = Mockito.mock(DocletEnvironment.class);
+        ElementUtil elementUtil = new ElementUtil(new String[0], new String[0]);
+        ClassLookup classLookup = new ClassLookup(environment);
+        referenceBuilder = new ReferenceBuilder(environment, classLookup, elementUtil);
+    }
+
+    @Test
+    public void expandComplexGenericsInReferences() {
+        MetadataFile classMetadataFile = new MetadataFile("path", "name");
+        MetadataFileItem referenceItem = new MetadataFileItem("a.b.c.List<df.mn.ClassOne<tr.T>>");
+        Set<MetadataFileItem> references = classMetadataFile.getReferences();
+        references.add(referenceItem);
+
+        referenceBuilder.expandComplexGenericsInReferences(classMetadataFile);
+
+        assertEquals("Wrong references amount", references.size(), 4);
+
+        List<String> content = references.stream().map(MetadataFileItem::getUid).collect(Collectors.toList());
+        assertTrue("Wrong references content", content.contains("a.b.c.List"));
+        assertTrue("Wrong references content", content.contains("df.mn.ClassOne"));
+        assertTrue("Wrong references content", content.contains("tr.T"));
+        assertTrue("Wrong references content", content.contains("a.b.c.List<df.mn.ClassOne<tr.T>>"));
+    }
+
+    //todo add test case to cover reference item with in package
+    @Test
+    public void buildRefItem() {
+        buildRefItemAndCheckAssertions("java.lang.Some.String", "java.lang.Some.String", "String");
+        buildRefItemAndCheckAssertions("java.lang.Some.String[]", "java.lang.Some.String[]", "String");
+    }
+
+    private void buildRefItemAndCheckAssertions(String initialValue, String expectedUid, String expectedName) {
+        MetadataFileItem result = referenceBuilder.buildRefItem(initialValue);
+
+        assertEquals("Wrong uid", result.getUid(), expectedUid);
+        assertEquals("Wrong name", result.getSpecForJava().iterator().next().getUid(), RegExUtils.removeAll(expectedUid, "\\[\\]$"));
+        assertEquals("Wrong name", result.getSpecForJava().iterator().next().getName(), expectedName);
+        assertEquals("Wrong fullName", result.getSpecForJava().iterator().next().getFullName(), RegExUtils.removeAll(expectedUid, "\\[\\]$"));
+    }
+
+    @Test
+    public void getJavaReferenceHref() {
+        String result1 = referenceBuilder.getJavaReferenceHref("java.lang.Object");
+        String result2 = referenceBuilder.getJavaReferenceHref("java.lang.Object.equals(java.lang.Object)");
+        String result3 = referenceBuilder.getJavaReferenceHref("java.lang.Object.notify()");
+        String result4 = referenceBuilder.getJavaReferenceHref("java.util.List");
+        String result5 = referenceBuilder.getJavaReferenceHref("java.lang.Object.wait(long,int)");
+        String result6 = referenceBuilder.getJavaReferenceHref("java.lang.Object.getClass()");
+        String result7 = referenceBuilder.getJavaReferenceHref("java.io.IOException");
+        String result8 = referenceBuilder.getJavaReferenceHref("java.io.InputStream");
+        String result9 = referenceBuilder.getJavaReferenceHref("java.lang.Enum.hashCode()");
+        String result10 = referenceBuilder.getJavaReferenceHref("java.nio.ByteBuffer");
+        String result11 = referenceBuilder.getJavaReferenceHref("java.lang.Enum.<T>valueOf(java.lang.Class<T>,java.lang.String)");
+        String result12 = referenceBuilder.getJavaReferenceHref("");
+        String result13 = referenceBuilder.getJavaReferenceHref(null);
+
+        String baseURL = "https://docs.oracle.com/javase/8/docs/api/";
+
+        assertEquals(baseURL + "java/lang/Object.html", result1);
+        assertEquals(baseURL + "java/lang/Object.html#equals-java.lang.Object-", result2);
+        assertEquals(baseURL + "java/lang/Object.html#notify--", result3);
+        assertEquals(baseURL + "java/util/List.html", result4);
+        assertEquals(baseURL + "java/lang/Object.html#wait-long-int-", result5);
+        assertEquals(baseURL + "java/lang/Object.html#getClass--", result6);
+        assertEquals(baseURL + "java/io/IOException.html", result7);
+        assertEquals(baseURL + "java/io/InputStream.html", result8);
+        assertEquals(baseURL + "java/lang/Enum.html#hashCode--", result9);
+        assertEquals(baseURL + "java/nio/ByteBuffer.html", result10);
+        assertEquals(baseURL + "java/lang/Enum.html#valueOf-java.lang.Class-java.lang.String-", result11);
+        assertEquals(baseURL, result12);
+        assertEquals(baseURL, result13);
+    }
+}

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/YmlFilesBuilderTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/YmlFilesBuilderTest.java
@@ -1,219 +1,29 @@
 package com.microsoft.build;
 
-import com.google.testing.compile.CompilationRule;
-import com.microsoft.model.*;
-import com.sun.source.util.DocTrees;
+import com.microsoft.model.TocItem;
+import com.microsoft.model.TocTypeMap;
 import jdk.javadoc.doclet.DocletEnvironment;
-import org.apache.commons.lang3.RegExUtils;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
-import java.io.File;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class YmlFilesBuilderTest {
 
-    @Rule
-    public CompilationRule rule = new CompilationRule();
-    private Elements elements;
     private YmlFilesBuilder ymlFilesBuilder;
     private DocletEnvironment environment;
-    private DocTrees docTrees;
 
     @Before
     public void setup() {
-        elements = rule.getElements();
         environment = Mockito.mock(DocletEnvironment.class);
-        docTrees = Mockito.mock(DocTrees.class);
         ymlFilesBuilder = new YmlFilesBuilder(environment, "./target", new String[]{}, new String[]{}, "google-cloud-product");
-    }
-
-    @Test
-    public void addConstructorsInfoWhenOnlyDefaultConstructor() {
-        TypeElement element = elements.getTypeElement("com.microsoft.samples.subpackage.Person");
-        MetadataFile container = new MetadataFile("output", "name");
-        when(environment.getElementUtils()).thenReturn(elements);
-        when(environment.getDocTrees()).thenReturn(docTrees);
-
-        ymlFilesBuilder.addConstructorsInfo(element, container);
-
-        assertEquals("Wrong file name", container.getFileNameWithPath(), "output" + File.separator + "name");
-        assertEquals("Container should contain constructor item", container.getItems().size(), 1);
-    }
-
-    @Test
-    public void addConstructorsInfo() {
-        TypeElement element = elements.getTypeElement("com.microsoft.samples.SuperHero");
-        MetadataFile container = new MetadataFile("output", "name");
-        when(environment.getElementUtils()).thenReturn(elements);
-        when(environment.getDocTrees()).thenReturn(docTrees);
-
-        ymlFilesBuilder.addConstructorsInfo(element, container);
-
-        assertEquals("Wrong file name", container.getFileNameWithPath(), "output" + File.separator + "name");
-        Collection<MetadataFileItem> constructorItems = container.getItems();
-        assertEquals("Container should contain 2 constructor items", constructorItems.size(), 2);
-    }
-
-    //todo add test case to cover reference item with in package
-    @Test
-    public void buildRefItem() {
-        buildRefItemAndCheckAssertions("java.lang.Some.String", "java.lang.Some.String", "String");
-        buildRefItemAndCheckAssertions("java.lang.Some.String[]", "java.lang.Some.String[]", "String");
-    }
-
-    private void buildRefItemAndCheckAssertions(String initialValue, String expectedUid, String expectedName) {
-        MetadataFileItem result = ymlFilesBuilder.buildRefItem(initialValue);
-
-        assertEquals("Wrong uid", result.getUid(), expectedUid);
-        assertEquals("Wrong name", result.getSpecForJava().iterator().next().getUid(), RegExUtils.removeAll(expectedUid, "\\[\\]$"));
-        assertEquals("Wrong name", result.getSpecForJava().iterator().next().getName(), expectedName);
-        assertEquals("Wrong fullName", result.getSpecForJava().iterator().next().getFullName(), RegExUtils.removeAll(expectedUid, "\\[\\]$"));
-    }
-
-    @Test
-    public void populateUidValues() {
-        MetadataFile classMetadataFile = new MetadataFile("output", "name");
-
-        MetadataFileItem ownerClassItem = buildMetadataFileItem("a.b.OwnerClass", "Not important summary value");
-        ownerClassItem.setNameWithType("OwnerClass");
-        MetadataFileItem item1 = buildMetadataFileItem("UID unknown class", "UnknownClass");
-        populateSyntax(item1, "SomeClass#someMethod(String param)");
-        MetadataFileItem item2 = buildMetadataFileItem("UID known class", "SomeClass#someMethod(String param)");
-        MetadataFileItem item3 = buildMetadataFileItem("UID method only", "#someMethod2(String p1, String p2)");
-        classMetadataFile.getItems().addAll(Arrays.asList(ownerClassItem, item1, item2, item3));
-
-        MetadataFileItem reference1 = new MetadataFileItem("a.b.SomeClass.someMethod(String param)");
-        reference1.setNameWithType("SomeClass.someMethod(String param)");
-        MetadataFileItem reference2 = new MetadataFileItem("a.b.OwnerClass.someMethod2(String p1, String p2)");
-        reference2.setNameWithType("OwnerClass.someMethod2(String p1, String p2)");
-        classMetadataFile.getReferences().addAll(Arrays.asList(reference1, reference2));
-
-        ymlFilesBuilder.populateUidValues(Collections.emptyList(), Arrays.asList(classMetadataFile));
-
-        assertEquals("Wrong summary for unknown class", item1.getSummary(),
-                "Bla bla <xref uid=\"\" data-throw-if-not-resolved=\"false\">UnknownClass</xref> bla");
-        assertEquals("Wrong syntax description", item1.getSyntax().getParameters().get(0).getDescription(),
-                "One two <xref uid=\"a.b.SomeClass.someMethod(String param)\" data-throw-if-not-resolved=\"false\">SomeClass#someMethod(String param)</xref> three");
-        assertEquals("Wrong summary for known class", item2.getSummary(),
-                "Bla bla <xref uid=\"a.b.SomeClass.someMethod(String param)\" data-throw-if-not-resolved=\"false\">SomeClass#someMethod(String param)</xref> bla");
-        assertEquals("Wrong summary for method", item3.getSummary(),
-                "Bla bla <xref uid=\"a.b.OwnerClass.someMethod2(String p1, String p2)\" data-throw-if-not-resolved=\"false\">#someMethod2(String p1, String p2)</xref> bla");
-
-    }
-
-    private MetadataFileItem buildMetadataFileItem(String uid, String value) {
-        MetadataFileItem item = new MetadataFileItem(uid);
-        item.setSummary(
-                String.format("Bla bla <xref uid=\"%s\" data-throw-if-not-resolved=\"false\">%s</xref> bla", value, value));
-        return item;
-    }
-
-    private void populateSyntax(MetadataFileItem item, String value) {
-        Syntax syntax = new Syntax();
-        String methodParamDescription = String
-                .format("One two <xref uid=\"%s\" data-throw-if-not-resolved=\"false\">%s</xref> three", value, value);
-        syntax.setParameters(
-                Arrays.asList(new MethodParameter("method param id", "method param type", methodParamDescription)));
-        item.setSyntax(syntax);
-    }
-
-    @Test
-    public void determineUidByLinkContent() {
-        Map<String, String> lookup = new HashMap<>() {{
-            put("SomeClass", "a.b.c.SomeClass");
-            put("SomeClass.someMethod()", "a.b.c.SomeClass.someMethod()");
-            put("SomeClass.someMethod(String param)", "a.b.c.SomeClass.someMethod(String param)");
-        }};
-
-        LookupContext lookupContext = new LookupContext(lookup, lookup);
-        assertEquals("Wrong result for class", ymlFilesBuilder.
-                resolveUidByLookup("SomeClass", lookupContext), "a.b.c.SomeClass");
-        assertEquals("Wrong result for method", ymlFilesBuilder.
-                resolveUidFromLinkContent("SomeClass#someMethod()", lookupContext), "a.b.c.SomeClass.someMethod()");
-        assertEquals("Wrong result for method with param", ymlFilesBuilder.
-                        resolveUidFromLinkContent("SomeClass#someMethod(String param)", lookupContext),
-                "a.b.c.SomeClass.someMethod(String param)");
-
-        assertEquals("Wrong result for unknown class", ymlFilesBuilder.
-                resolveUidByLookup("UnknownClass", lookupContext), "");
-        assertEquals("Wrong result for null", ymlFilesBuilder.resolveUidByLookup(null, lookupContext), "");
-        assertEquals("Wrong result for whitespace", ymlFilesBuilder.resolveUidByLookup(" ", lookupContext), "");
-    }
-
-    @Test
-    public void splitUidWithGenericsIntoClassNames() {
-        List<String> result = ymlFilesBuilder.splitUidWithGenericsIntoClassNames("a.b.c.List<df.mn.ClassOne<tr.T>>");
-
-        assertEquals("Wrong result list size", result.size(), 3);
-        assertTrue("Wrong result list content", result.contains("a.b.c.List"));
-        assertTrue("Wrong result list content", result.contains("df.mn.ClassOne"));
-        assertTrue("Wrong result list content", result.contains("tr.T"));
-    }
-
-    @Test
-    public void expandComplexGenericsInReferences() {
-        MetadataFile classMetadataFile = new MetadataFile("path", "name");
-        MetadataFileItem referenceItem = new MetadataFileItem("a.b.c.List<df.mn.ClassOne<tr.T>>");
-        Set<MetadataFileItem> references = classMetadataFile.getReferences();
-        references.add(referenceItem);
-
-        ymlFilesBuilder.expandComplexGenericsInReferences(classMetadataFile);
-
-        assertEquals("Wrong references amount", references.size(), 4);
-
-        List<String> content = references.stream().map(MetadataFileItem::getUid).collect(Collectors.toList());
-        assertTrue("Wrong references content", content.contains("a.b.c.List"));
-        assertTrue("Wrong references content", content.contains("df.mn.ClassOne"));
-        assertTrue("Wrong references content", content.contains("tr.T"));
-        assertTrue("Wrong references content", content.contains("a.b.c.List<df.mn.ClassOne<tr.T>>"));
-    }
-
-
-    @Test
-    public void getJavaReferenceHref(){
-        String result1 = ymlFilesBuilder.getJavaReferenceHref("java.lang.Object");
-        String result2 = ymlFilesBuilder.getJavaReferenceHref("java.lang.Object.equals(java.lang.Object)");
-        String result3 = ymlFilesBuilder.getJavaReferenceHref("java.lang.Object.notify()");
-        String result4 = ymlFilesBuilder.getJavaReferenceHref("java.util.List");
-        String result5 = ymlFilesBuilder.getJavaReferenceHref("java.lang.Object.wait(long,int)");
-        String result6 = ymlFilesBuilder.getJavaReferenceHref("java.lang.Object.getClass()");
-        String result7 = ymlFilesBuilder.getJavaReferenceHref("java.io.IOException");
-        String result8 = ymlFilesBuilder.getJavaReferenceHref("java.io.InputStream");
-        String result9 = ymlFilesBuilder.getJavaReferenceHref("java.lang.Enum.hashCode()");
-        String result10 = ymlFilesBuilder.getJavaReferenceHref("java.nio.ByteBuffer");
-        String result11 = ymlFilesBuilder.getJavaReferenceHref("java.lang.Enum.<T>valueOf(java.lang.Class<T>,java.lang.String)");
-        String result12 = ymlFilesBuilder.getJavaReferenceHref("");
-        String result13 = ymlFilesBuilder.getJavaReferenceHref(null);
-
-        String baseURL = "https://docs.oracle.com/javase/8/docs/api/";
-
-        assertEquals(baseURL + "java/lang/Object.html", result1);
-        assertEquals(baseURL + "java/lang/Object.html#equals-java.lang.Object-", result2);
-        assertEquals(baseURL + "java/lang/Object.html#notify--", result3);
-        assertEquals(baseURL + "java/util/List.html", result4);
-        assertEquals(baseURL + "java/lang/Object.html#wait-long-int-", result5);
-        assertEquals(baseURL + "java/lang/Object.html#getClass--", result6);
-        assertEquals(baseURL + "java/io/IOException.html", result7);
-        assertEquals(baseURL + "java/io/InputStream.html", result8);
-        assertEquals(baseURL + "java/lang/Enum.html#hashCode--", result9);
-        assertEquals(baseURL + "java/nio/ByteBuffer.html", result10);
-        assertEquals(baseURL + "java/lang/Enum.html#valueOf-java.lang.Class-java.lang.String-", result11);
-        assertEquals(baseURL, result12);
-        assertEquals(baseURL, result13);
     }
 
     @Test
@@ -248,5 +58,4 @@ public class YmlFilesBuilderTest {
         assertEquals("Exceptions", tocItems.get(8).getHeading());
         assertEquals(exceptionToc, tocItems.get(9));
     }
-
 }


### PR DESCRIPTION
Break up YmlFilesBuilder into multiple builders to make it easier to follow code and make changes. This change doesn't change any code, it just moves code into new files. There was way too much packed into this one file originally