### PR TITLE
fix: cleanup @links in docs

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/util/YamlUtil.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/util/YamlUtil.java
@@ -32,7 +32,9 @@ public class YamlUtil {
                 .replaceAll("<([A-Z][a-z]+||)>", "&lt;$1&gt;")
                 .replaceAll("`([^`]+)`", "<code>$1</code>")
                 .replaceAll("\\[([^]]+)]\\(([^)]+)\\)", "<a href=\"$2\">$1</a>")
+                .replaceAll("\\{@link *\"([^\\{]+)\" *\\}", "<a href=\"$1\">$1</a>")
                 .replaceAll("\\[([^]]+)]\\[([^]]+)\\]", "<xref uid=\"$2\" data-throw-if-not-resolved=\"false\">$1</xref>")
+                .replaceAll("\\{@link *([^\\{\"]+) *\\}", "<xref uid=\"$1\" data-throw-if-not-resolved=\"false\">$1</xref>")
                 .replaceAll("==+([^=]+)==+", "<h2>$1</h2>");
     }
 }

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/samples/google/v1p1alpha/SpeechClient.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/samples/google/v1p1alpha/SpeechClient.java
@@ -108,6 +108,8 @@ public class SpeechClient implements BackgroundResource {
   /**
    * Constructs an instance of SpeechClient, using the given settings. The channels are created
    * based on the settings passed in, or defaults for any settings that are not set.
+   * Example broken links: {@link "http://tools.ietf.org/html/rfc2616#section-3.7"}
+   * {@link ApiFutures#immediateFuture(null)}.
    */
   public static final SpeechClient create(com.microsoft.samples.google.SpeechSettings settings) throws IOException {
     return new SpeechClient(settings);

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/util/YamlUtilTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/util/YamlUtilTest.java
@@ -143,4 +143,26 @@ public class YamlUtilTest {
         assertEquals("[uid]][text]", YamlUtil.cleanupHtml("[uid]][text]"));
         assertFalse(YamlUtil.cleanupHtml("[text[uid]]").contains("xref"));
     }
+
+    @Test
+    public void cleanupHtmlLinkTagWithLinkTest() {
+        String expectedActual = "{@link \"http://www.bad-way-to-include-link.com#section\"}";
+        String expectedResult = "<a href=\"http://www.bad-way-to-include-link.com#section\">http://www.bad-way-to-include-link.com#section</a>";
+        String random = UUID.randomUUID().toString();
+
+        assertEquals(expectedResult, YamlUtil.cleanupHtml(expectedActual));
+        assertEquals(random + expectedResult + random, YamlUtil.cleanupHtml(random + expectedActual + random));
+        assertEquals(expectedResult + random + expectedResult, YamlUtil.cleanupHtml(expectedActual + random + expectedActual));
+    }
+
+    @Test
+    public void cleanupHtmlLinkTagNotRecognizedTest() {
+        String expectedActual = "{@link WeirdLink#didntResolve(null)}";
+        String expectedResult = "<xref uid=\"WeirdLink#didntResolve(null)\" data-throw-if-not-resolved=\"false\">WeirdLink#didntResolve(null)</xref>";
+        String random = UUID.randomUUID().toString();
+
+        assertEquals(expectedResult, YamlUtil.cleanupHtml(expectedActual));
+        assertEquals(random + expectedResult + random, YamlUtil.cleanupHtml(random + expectedActual + random));
+        assertEquals(expectedResult + random + expectedResult, YamlUtil.cleanupHtml(expectedActual + random + expectedActual));
+    }
 }

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1p1alpha.SpeechClient.yml
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1p1alpha.SpeechClient.yml
@@ -170,7 +170,7 @@ items:
   overload: "com.microsoft.samples.google.v1p1alpha.SpeechClient.create*"
   type: "Method"
   package: "com.microsoft.samples.google.v1p1alpha"
-  summary: "Constructs an instance of SpeechClient, using the given settings. The channels are created\n based on the settings passed in, or defaults for any settings that are not set."
+  summary: "Constructs an instance of SpeechClient, using the given settings. The channels are created\n based on the settings passed in, or defaults for any settings that are not set.\n Example broken links: <a href=\"http://tools.ietf.org/html/rfc2616#section-3.7\">http://tools.ietf.org/html/rfc2616#section-3.7</a>\n <xref uid=\"\" data-throw-if-not-resolved=\"false\">ApiFutures#immediateFuture(null)</xref>."
   syntax:
     content: "public static final SpeechClient create(SpeechSettings settings)"
     parameters:


### PR DESCRIPTION
Fixes #208292008

Ideally we shouldn't do this in source code, but it happens - this fixes us literally including "@link...." in documentation