### PR TITLE
feat: disableChangelog option

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
@@ -25,18 +25,20 @@ public class YmlFilesBuilder {
     private ElementUtil elementUtil;
     private PackageLookup packageLookup;
     private String projectName;
+    private boolean disableChangelog;
     private ProjectBuilder projectBuilder;
     private PackageBuilder packageBuilder;
     private ClassBuilder classBuilder;
     private ReferenceBuilder referenceBuilder;
 
     public YmlFilesBuilder(DocletEnvironment environment, String outputPath,
-                           String[] excludePackages, String[] excludeClasses, String projectName) {
+                           String[] excludePackages, String[] excludeClasses, String projectName, boolean disableChangelog) {
         this.environment = environment;
         this.outputPath = outputPath;
         this.elementUtil = new ElementUtil(excludePackages, excludeClasses);
         this.packageLookup = new PackageLookup(environment);
         this.projectName = projectName;
+        this.disableChangelog = disableChangelog;
         this.projectBuilder = new ProjectBuilder(projectName);
         ClassLookup classLookup = new ClassLookup(environment);
         this.referenceBuilder = new ReferenceBuilder(environment, classLookup, elementUtil);
@@ -46,7 +48,7 @@ public class YmlFilesBuilder {
 
     public boolean build() {
         //  table of contents
-        TocFile tocFile = new TocFile(outputPath, projectName);
+        TocFile tocFile = new TocFile(outputPath, projectName, disableChangelog);
         //  overview page
         MetadataFile projectMetadataFile = new MetadataFile(outputPath, "overview.yml");
         //  package summary pages

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/doclet/DocFxDoclet.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/doclet/DocFxDoclet.java
@@ -25,9 +25,10 @@ public class DocFxDoclet implements Doclet {
         reporter.print(Kind.NOTE, "Output path: " + outputPath);
         reporter.print(Kind.NOTE, "Excluded packages: " + Arrays.toString(excludePackages));
         reporter.print(Kind.NOTE, "Excluded classes: " + Arrays.toString(excludeClasses));
-        reporter.print(Kind.NOTE, "Project Name: " + projectName);
+        reporter.print(Kind.NOTE, "Project name: " + projectName);
+        reporter.print(Kind.NOTE, "Disable changelog: " + disableChangelog);
 
-        return (new YmlFilesBuilder(environment, outputPath, excludePackages, excludeClasses, projectName)).build();
+        return (new YmlFilesBuilder(environment, outputPath, excludePackages, excludeClasses, projectName, disableChangelog)).build();
     }
 
     @Override
@@ -39,6 +40,7 @@ public class DocFxDoclet implements Doclet {
     private String[] excludePackages = {};
     private String[] excludeClasses = {};
     private String projectName;
+    private boolean disableChangelog;
 
     @Override
     public Set<? extends Option> getSupportedOptions() {
@@ -72,6 +74,18 @@ public class DocFxDoclet implements Doclet {
                     public boolean process(String option, List<String> arguments) {
                         //  using artifact id as projectName - remove "-parent" since generation runs in parent pom
                         projectName = arguments.get(0).replaceAll("-parent", "");
+                        return true;
+                    }
+                },
+                new CustomOption(
+                        "Disable changelog", Arrays.asList("-disable-changelog", "--disable-changelog"), "disableChangelog") {
+                    @Override
+                    public boolean process(String option, List<String> arguments) {
+                        if (arguments.get(0).equalsIgnoreCase("false")){
+                            disableChangelog = false;
+                        } else {
+                            disableChangelog = true;
+                        }
                         return true;
                     }
                 },

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/TocContents.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/TocContents.java
@@ -23,22 +23,24 @@ public class TocContents {
     private final String projectName;
     private final List<Object> contents = new ArrayList<>();
 
-    public TocContents(String projectName, List<TocItem> items) {
+    public TocContents(String projectName, boolean disableChangelog, List<TocItem> items) {
         this.projectName = projectName;
 
         if (projectName == null || projectName.equals("")) {
             contents.addAll(items);
         } else {
             //  only include product hierarchy and guides if projectName included
-            createTocContents(projectName, items);
+            createTocContents(projectName, disableChangelog, items);
         }
     }
 
-    private void createTocContents(String projectName, List<TocItem> items) {
+    private void createTocContents(String projectName, boolean disableChangelog, List<TocItem> items) {
         List<Object> tocItems = new ArrayList<>();
         // combine guides and tocItems
         tocItems.add(new Guide("Overview", "overview.html"));
-        tocItems.add(new Guide("Version history", "history.md"));
+        if (!disableChangelog) {
+            tocItems.add(new Guide("Version history", "history.md"));
+        }
         tocItems.addAll(items);
         // wrap guides + tocItems with product hierarchy
         contents.add(new ProjectContents(projectName, tocItems));

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/TocFile.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/TocFile.java
@@ -14,10 +14,12 @@ public class TocFile extends ArrayList<TocItem> implements YmlFile {
     private final static String TOC_FILE_NAME = "toc.yml";
     private final String outputPath;
     private final String projectName;
+    private final boolean disableChangelog;
 
-    public TocFile(String outputPath, String projectName) {
+    public TocFile(String outputPath, String projectName, boolean disableChangelog) {
         this.outputPath = outputPath;
         this.projectName = projectName;
+        this.disableChangelog = disableChangelog;
     }
 
     public void addTocItem(TocItem packageTocItem) {
@@ -31,7 +33,7 @@ public class TocFile extends ArrayList<TocItem> implements YmlFile {
     @Override
     public String getFileContent() {
         sortByUid();
-        List<Object> tocContents = new TocContents(projectName, this).getContents();
+        List<Object> tocContents = new TocContents(projectName, disableChangelog, this).getContents();
         return TOC_FILE_HEADER + YamlUtil.objectToYamlString(tocContents);
     }
 

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/YmlFilesBuilderTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/build/YmlFilesBuilderTest.java
@@ -23,7 +23,7 @@ public class YmlFilesBuilderTest {
     @Before
     public void setup() {
         environment = Mockito.mock(DocletEnvironment.class);
-        ymlFilesBuilder = new YmlFilesBuilder(environment, "./target", new String[]{}, new String[]{}, "google-cloud-product");
+        ymlFilesBuilder = new YmlFilesBuilder(environment, "./target", new String[]{}, new String[]{}, "google-cloud-product", false);
     }
 
     @Test

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/model/TocContentsTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/model/TocContentsTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class TocContentsTest {
 
@@ -31,6 +32,7 @@ public class TocContentsTest {
     private TocItem tocItemC;
     private List<TocItem> tocItems;
     private String projectName = "google-cloud-project";
+    private boolean disableChangelog = false;
 
     @Before
     public void setup() {
@@ -47,7 +49,7 @@ public class TocContentsTest {
     @Test
     public void getContentsWithProjectName() {
         //  should include ProjectContents and Guides
-        List<Object> tocContents = new TocContents(projectName, tocItems).getContents();
+        List<Object> tocContents = new TocContents(projectName, disableChangelog, tocItems).getContents();
 
         assertEquals("Should only include 1 item", tocContents.size(), 1);
         assertEquals("Should include ProjectContents", tocContents.get(0).getClass(), ProjectContents.class);
@@ -73,12 +75,29 @@ public class TocContentsTest {
 
     @Test
     public void getContentsNoProjectName() {
-        List<Object> tocContents = new TocContents("", tocItems).getContents();
+        List<Object> tocContents = new TocContents("", disableChangelog, tocItems).getContents();
 
         //  should not include ProjectContents or Guides
         assertEquals("Should be 3 items", tocContents.size(), 3);
         assertEquals("Item A should be first", tocContents.get(0), tocItemA);
         assertEquals("Item B should be second", tocContents.get(1), tocItemB);
         assertEquals("Item C should be third", tocContents.get(2), tocItemC);
+    }
+
+    @Test
+    public void getContentsWithDisabledChangelog() {
+        disableChangelog = true;
+        List<Object> tocContents = new TocContents(projectName, disableChangelog, tocItems).getContents();
+
+        ProjectContents contents = (ProjectContents) tocContents.get(0);
+        List<Object> items = contents.getItems();
+        assertEquals("Should be 4 items", items.size(), 4);
+
+        Guide overview = (Guide) items.get(0);
+        assertEquals("First guide should be Overview", overview.getName(), "Overview");
+        assertNotEquals("Second item should not be Version History guide", items.get(1).getClass(), Guide.class);
+        assertEquals("Item A should be second", items.get(1), tocItemA);
+        assertEquals("Item B should be third", items.get(2), tocItemB);
+        assertEquals("Item C should be fourth", items.get(3), tocItemC);
     }
 }

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/model/TocFileTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/model/TocFileTest.java
@@ -24,7 +24,7 @@ public class TocFileTest {
 
     @Test
     public void sortsByUid() {
-        TocFile tocFile = new TocFile("outputPath", "google-cloud-project");
+        TocFile tocFile = new TocFile("outputPath", "google-cloud-project", false);
         TocItem tocItemA = new TocItem("A.uid.package.class", "name");
         TocItem tocItemB = new TocItem("B.uid.package.class", "name");
         TocItem tocItemC = new TocItem("C.uid.package.class", "name");


### PR DESCRIPTION
Fixes #118 

Changelog in toc implemented as "version history" guide will continue to be included as long as -disable-changelog is not provided or -disable-changelog=false is provided.

To disable this feat, include -disable-changelog option now.