### PR TITLE
feat: make DocletRunner runnable for options file and argfile

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/doclet/DocletRunner.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/doclet/DocletRunner.java
@@ -1,27 +1,33 @@
 package com.microsoft.doclet;
 
 import com.microsoft.util.OptionsFileUtil;
-
+import java.util.ArrayList;
+import java.util.List;
 import javax.tools.ToolProvider;
 
 /**
- * To use runner just pass as commandline param to main method:
- * - name of file with doclet name amd params
- * <p>
- * For example: java DocletRunner src\test\resources\test-doclet-params.txt
+ * To use runner just pass as commandline param to main method: - name of file with doclet name,
+ * parameter file, and argument file.
+ *
+ * <p>For example: <code>java DocletRunner $HOME/java-aiplatform/target/site/apidocs/options
+ *     $HOME/java-aiplatform/target/site/apidocs/argfile</code>
  */
 public class DocletRunner {
 
     public static void main(final String[] args) {
-        if (args.length != 1) {
-            System.err.println("Usage: java DocletRunner <doclet-params-filename>");
-            return;
-        }
-        if (!(new java.io.File(args[0])).isFile()) {
-            System.err.println(String.format("File '%s' does not exist", args[0]));
+        if (args.length < 1) {
+            System.err.println("Usage: java DocletRunner <options file> <argfile>");
             return;
         }
 
-        ToolProvider.getSystemDocumentationTool().run(null, null, null, OptionsFileUtil.processOptionsFile(args[0]));
+        List<String> combined = new ArrayList<>();
+        for (String arg : args) {
+            if (!(new java.io.File(arg)).isFile()) {
+                System.err.println(String.format("File '%s' does not exist", args[0]));
+            }
+            combined.addAll(OptionsFileUtil.processOptionsFile(arg));
+        }
+        ToolProvider.getSystemDocumentationTool()
+            .run(null, null, null, combined.toArray(new String[0]));
     }
 }

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/util/OptionsFileUtil.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/util/OptionsFileUtil.java
@@ -9,7 +9,7 @@ import java.util.StringTokenizer;
 
 public class OptionsFileUtil {
 
-    public static String[] processOptionsFile(String filename) {
+    public static List<String> processOptionsFile(String filename) {
         List<String> jargs = new ArrayList<>();
 
         String options = readOptionsFromFile(filename);
@@ -18,7 +18,7 @@ public class OptionsFileUtil {
             jargs.add(tokens.nextToken());
         }
 
-        return jargs.toArray(new String[0]);
+        return jargs;
     }
 
     private static String readOptionsFromFile(String filename) {
@@ -26,7 +26,9 @@ public class OptionsFileUtil {
         try (BufferedReader bufferedReader = new BufferedReader(new FileReader(filename))) {
             String line;
             while ((line = bufferedReader.readLine()) != null) {
-                buffer.append(line).append("\n");
+                // remove single quote at the head and tail
+                String trimmedLine = line.replaceAll("^'|'$", "");
+                buffer.append(trimmedLine).append("\n");
             }
         } catch (IOException ioe) {
             buffer.setLength(0);

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/doclet/DocletRunnerTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/doclet/DocletRunnerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class DocletRunnerTest {
 
@@ -45,15 +46,18 @@ public class DocletRunnerTest {
         DocletRunner.main(new String[]{});
 
         assertEquals("Wrong System.err content",
-                errContent.toString().trim(), "Usage: java DocletRunner <doclet-params-filename>");
+                errContent.toString().trim(), "Usage: java DocletRunner <options file> <argfile>");
     }
 
     @Test
     public void testFilesGenerationWhenTargetFileDoesNotExist() {
-        DocletRunner.main(new String[]{"some-name.txt"});
-
-        assertEquals("Wrong System.err content",
+        try {
+            DocletRunner.main(new String[]{"some-name.txt"});
+            fail();
+        } catch (RuntimeException ex) {
+            assertEquals("Wrong System.err content",
                 errContent.toString().trim(), "File 'some-name.txt' does not exist");
+        }
     }
 
     @Test

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/util/OptionsFileUtilTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/util/OptionsFileUtilTest.java
@@ -1,8 +1,6 @@
 package com.microsoft.util;
 
 import org.junit.Test;
-
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -13,7 +11,7 @@ public class OptionsFileUtilTest {
 
     @Test
     public void processOptionsFile() {
-        List<String> strings = Arrays.asList(OptionsFileUtil.processOptionsFile(PARAMS_DIR));
+        List<String> strings = OptionsFileUtil.processOptionsFile(PARAMS_DIR);
 
         assertTrue("Wrong result", strings.contains("-doclet"));
         assertTrue("Wrong result", strings.contains("com.microsoft.doclet.DocFxDoclet"));

--- a/third_party/docfx-doclet-143274/src/test/resources/test-doclet-params.txt
+++ b/third_party/docfx-doclet-143274/src/test/resources/test-doclet-params.txt
@@ -1,4 +1,5 @@
--doclet com.microsoft.doclet.DocFxDoclet
+-doclet
+'com.microsoft.doclet.DocFxDoclet'
 -sourcepath ./src/test/java
 -outputpath ./target/test-out
 -encoding UTF-8


### PR DESCRIPTION
You can run `com.microsoft.doclet.DocletRunner` with arguments (options and argfile).