### PR TITLE
feat: Allow unicode javadoc comments

### DIFF
--- a/third_party/docfx-doclet-143274/pom.xml
+++ b/third_party/docfx-doclet-143274/pom.xml
@@ -17,6 +17,7 @@
     <apache.commons-lang.version>3.12.0</apache.commons-lang.version>
     <apache.commons-collections.version>4.4</apache.commons-collections.version>
     <apache.commons-io.version>2.11.0</apache.commons-io.version>
+    <apache.commons-text.version>1.10.0</apache.commons-text.version>
     <remark.version>1.1.0</remark.version>
   </properties>
 
@@ -110,6 +111,11 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${apache.commons-io.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>${apache.commons-text.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/lookup/BaseLookup.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/lookup/BaseLookup.java
@@ -13,14 +13,13 @@ import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.LinkTree;
 import com.sun.source.doctree.LiteralTree;
 import com.sun.source.doctree.SeeTree;
-import java.util.concurrent.ConcurrentHashMap;
 import jdk.javadoc.doclet.DocletEnvironment;
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -242,7 +241,7 @@ public abstract class BaseLookup<T extends Element> {
                     case LITERAL:
                         return expandLiteralBody((LiteralTree) bodyItem);
                     default:
-                        return String.valueOf(bodyItem);
+                        return String.valueOf(StringEscapeUtils.unescapeJava(bodyItem.toString()));
                 }
             }
         ).collect(Collectors.joining()));

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/lookup/BaseLookup.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/lookup/BaseLookup.java
@@ -260,11 +260,11 @@ public abstract class BaseLookup<T extends Element> {
     }
 
     String buildCodeTag(LiteralTree literalTree) {
-        return String.format("<code>%s</code>", literalTree.getBody());
+        return String.format("<code>%s</code>", StringEscapeUtils.unescapeJava(literalTree.getBody().toString()));
     }
 
     String expandLiteralBody(LiteralTree bodyItem) {
-        return String.valueOf(bodyItem.getBody());
+        return String.valueOf(StringEscapeUtils.unescapeJava(bodyItem.getBody().toString()));
     }
 
     protected Optional<DocCommentTree> getDocCommentTree(T element) {

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/lookup/BaseLookupTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/lookup/BaseLookupTest.java
@@ -134,7 +134,7 @@ public class BaseLookupTest {
 
     @Test
     public void buildCodeTag() {
-        String tagContent = "Some text";
+        String tagContent = "Some text ≤";
         when(literalTree.getBody()).thenReturn(textTree);
         when(textTree.toString()).thenReturn(tagContent);
 
@@ -145,13 +145,14 @@ public class BaseLookupTest {
 
     @Test
     public void expandLiteralBody() {
-        String tagContent = "Some text";
+        String tagContent = "Some text ≤ \u2264";
         when(literalTree.getBody()).thenReturn(textTree);
         when(textTree.toString()).thenReturn(tagContent);
 
         String result = baseLookup.expandLiteralBody(literalTree);
+        String expected = "Some text ≤ ≤";
 
-        assertEquals("Wrong result", result, tagContent);
+        assertEquals("Wrong result", result, expected);
     }
 
     @Test
@@ -159,7 +160,7 @@ public class BaseLookupTest {
         when(linkTree.getReference()).thenReturn(referenceTree);
         when(referenceTree.getSignature()).thenReturn("Some#signature");
         when(linkTree.getLabel()).thenReturn(Collections.emptyList());
-        String textTreeContent = "Some text content";
+        String textTreeContent = "Some text content ≤ \u2264";
         when(literalTree.getBody()).thenReturn(textTree);
         when(textTree.toString()).thenReturn(textTreeContent);
         when(linkTree.getKind()).thenReturn(Kind.LINK);
@@ -169,7 +170,7 @@ public class BaseLookupTest {
         String result = baseLookup.replaceLinksAndCodes(Arrays.asList(linkTree, literalTree, textTree));
 
         assertEquals("Wrong result", result, "<xref uid=\"Some#signature\" data-throw-if-not-resolved=\"false\">"
-                + "Some#signature</xref><code>Some text content</code>" + textTreeContent);
+                + "Some#signature</xref><code>Some text content ≤ ≤</code>" + textTreeContent);
     }
 
     @Test


### PR DESCRIPTION
Fixes #161

This is the new `...Field.Builder.yml` file:
```
- uid: "com.google.cloud.bigquery.Field.Builder.setPrecision(java.lang.Long)"
  id: "setPrecision(java.lang.Long)"
  parent: "com.google.cloud.bigquery.Field.Builder"
  langs:
  - "java"
  name: "setPrecision(Long precision)"
  nameWithType: "Field.Builder.setPrecision(Long precision)"
  fullName: "com.google.cloud.bigquery.Field.Builder.setPrecision(Long precision)"
  overload: "com.google.cloud.bigquery.Field.Builder.setPrecision*"
  type: "Method"
  package: "com.google.cloud.bigquery"
  summary: "Precision can be used to constrain the maximum number of total digits allowed for NUMERIC or\n BIGNUMERIC types. It is invalid to set values for Precision for types other than // NUMERIC\n or BIGNUMERIC. For NUMERIC type, acceptable values for Precision must be: 1 ≤ (Precision -\n Scale) ≤ 29. Values for Scale must be: 0 ≤ Scale ≤ 9. For BIGNUMERIC type, acceptable values\n for Precision must be: 1 ≤ (Precision - Scale) ≤ 38. Values for Scale must be: 0 ≤ Scale ≤\n 38."
  syntax:
    content: "public Field.Builder setPrecision(Long precision)"
    parameters:
    - id: "precision"
      type: "java.lang.Long"
    return:
      type: "com.google.cloud.bigquery.Field.Builder"
```

Issue seems to be from `bodyItem.toString()` (https://www.javadoc.io/static/org.kohsuke.sorcerer/sorcerer-javac/0.11/com/sun/tools/javac/tree/DCTree.DCText.html) which renders the with unicode escapes. Use apache-commons-text to render the unicode escapes back to unicode values.