### PR TITLE
chore: support injectable env vars for testing

### DIFF
--- a/third_party/docfx-doclet-143274/pom.xml
+++ b/third_party/docfx-doclet-143274/pom.xml
@@ -191,12 +191,6 @@
       <version>4.22.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.github.stefanbirkner</groupId>
-      <artifactId>system-rules</artifactId>
-      <version>1.19.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <repositories>

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/doclet/DocFxDoclet.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/doclet/DocFxDoclet.java
@@ -21,14 +21,11 @@ public class DocFxDoclet implements Doclet {
 
   @Override
   public boolean run(DocletEnvironment environment) {
-    String artifactVersion = System.getenv("artifactVersion");
-    String librariesBomVersion = System.getenv("librariesBomVersion");
-    String repoMetadataFilePath = System.getenv("repoMetadataFilePath");
-    Objects.requireNonNull(
-        repoMetadataFilePath, "Environment variable 'repoMetadataFilePath' must not be null.");
-    reporter.print(Kind.NOTE, "Environment variable artifactVersion: " + artifactVersion);
-    reporter.print(Kind.NOTE, "Environment variable librariesBomVersion: " + librariesBomVersion);
-    reporter.print(Kind.NOTE, "Environment variable repoMetadataFilePath: " + repoMetadataFilePath);
+    Objects.requireNonNull(repoMetadataFilePath, "repoMetadataFilePath must not be null.");
+
+    reporter.print(Kind.NOTE, "artifactVersion: " + artifactVersion);
+    reporter.print(Kind.NOTE, "librariesBomVersion: " + librariesBomVersion);
+    reporter.print(Kind.NOTE, "repoMetadataFilePath: " + repoMetadataFilePath);
     reporter.print(Kind.NOTE, "Output path: " + outputPath);
     reporter.print(Kind.NOTE, "Excluded packages: " + Arrays.toString(excludePackages));
     reporter.print(Kind.NOTE, "Excluded classes: " + Arrays.toString(excludeClasses));
@@ -61,6 +58,9 @@ public class DocFxDoclet implements Doclet {
   private String projectName;
   private boolean disableChangelog;
   private boolean disableLibraryOverview;
+  private String artifactVersion;
+  private String librariesBomVersion;
+  private String repoMetadataFilePath;
 
   @Override
   public Set<? extends Option> getSupportedOptions() {
@@ -127,6 +127,36 @@ public class DocFxDoclet implements Doclet {
           } else {
             disableLibraryOverview = true;
           }
+          return true;
+        }
+      },
+      new CustomOption(
+          "Artifact Version",
+          Arrays.asList("-artifactVersion", "--artifactVersion"),
+          "artifactVersion") {
+        @Override
+        public boolean process(String option, List<String> arguments) {
+          artifactVersion = arguments.get(0);
+          return true;
+        }
+      },
+      new CustomOption(
+          "libraries-bom Version",
+          Arrays.asList("-librariesBomVersion", "--librariesBomVersion"),
+          "librariesBomVersion") {
+        @Override
+        public boolean process(String option, List<String> arguments) {
+          librariesBomVersion = arguments.get(0);
+          return true;
+        }
+      },
+      new CustomOption(
+          "repo-metadata.json File Path",
+          Arrays.asList("-repoMetadataFilePath", "--repoMetadataFilePath"),
+          "repoMetadataFilePath") {
+        @Override
+        public boolean process(String option, List<String> arguments) {
+          repoMetadataFilePath = arguments.get(0);
           return true;
         }
       },

--- a/third_party/docfx-doclet-143274/src/test/java/com/microsoft/doclet/DocletRunnerTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/microsoft/doclet/DocletRunnerTest.java
@@ -2,7 +2,6 @@ package com.microsoft.doclet;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import com.microsoft.util.FileUtilTest;
@@ -15,9 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 public class DocletRunnerTest {
 
@@ -29,8 +26,6 @@ public class DocletRunnerTest {
   private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
   private final PrintStream originalOut = System.out;
   private final PrintStream originalErr = System.err;
-
-  @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   @Before
   public void cleanup() throws IOException {
@@ -71,17 +66,14 @@ public class DocletRunnerTest {
 
   @Test
   public void testFilesGeneration() throws IOException {
-    environmentVariables.set("artifactVersion", "0.18.0");
-    environmentVariables.set("librariesBomVersion", "26.19.0");
-    environmentVariables.set(
-        "repoMetadataFilePath", "./src/test/java/com/microsoft/samples/.repo-metadata.json");
-    assertEquals("0.18.0", System.getenv("artifactVersion"));
-    assertEquals("26.19.0", System.getenv("librariesBomVersion"));
-    assertEquals(
-        "./src/test/java/com/microsoft/samples/.repo-metadata.json",
-        System.getenv("repoMetadataFilePath"));
-
-    DocletRunner.main(new String[] {PARAMS_DIR});
+    DocletRunner.run(
+        new String[] {PARAMS_DIR},
+        new DocletRunner.EnvironmentToArgumentsBuilder()
+            .add("artifactVersion", "0.18.0")
+            .add("librariesBomVersion", "26.19.0")
+            .add(
+                "repoMetadataFilePath", "./src/test/java/com/microsoft/samples/.repo-metadata.json")
+            .build());
 
     List<Path> expectedFilePaths =
         Files.list(Path.of(EXPECTED_GENERATED_FILES_DIR)).sorted().collect(Collectors.toList());
@@ -111,12 +103,6 @@ public class DocletRunnerTest {
             generatedFileLines[i]);
       }
     }
-    environmentVariables.clear("artifactVersion");
-    environmentVariables.clear("librariesBomVersion");
-    environmentVariables.clear("repoMetadataFilePath");
-    assertNull(System.getenv("artifactVersion"));
-    assertNull(System.getenv("librariesBomVersion"));
-    assertNull(System.getenv("repoMetadataFilePath"));
   }
 
   public void assertSameFileNames(List<Path> expected, List<Path> generated) {


### PR DESCRIPTION
Removes 3rd party dependency. Environment variables now converted to consistent format for `DocFxDoclet`