### PR TITLE
fix: initialize uncategorized array

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/StubPackageToc.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/StubPackageToc.java
@@ -18,6 +18,7 @@ public class StubPackageToc {
     visibleCategories.put(STUBS, new ArrayList<>());
     visibleCategories.put(SETTINGS, new ArrayList<>());
     visibleCategories.put(CALLABLE_FACTORIES, new ArrayList<>());
+    visibleCategories.put(UNCATEGORIZED, new ArrayList<>());
   }
 
   public void addStub(TocItem tocItem) {


### PR DESCRIPTION
As part of testing javadoc generation for handwritten libraries with the newest version of the doclet, bigquerystorage was failing:

```
15:00:15:365 [ERROR] error: fatal error encountered: java.lang.NullPointerException: Cannot invoke "java.util.List.add(Object)" because the return value of "java.util.LinkedHashMap.get(Object)" is null
15:00:15:365 [ERROR] error: Please file a bug against the javadoc tool via the Java bug reporting page
15:00:15:365 [ERROR]   (https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com)
15:00:15:365 [ERROR]   for duplicates. Include error messages and the following diagnostic in your report. Thank you.
15:00:15:365 [ERROR] java.lang.NullPointerException: Cannot invoke "java.util.List.add(Object)" because the return value of "java.util.LinkedHashMap.get(Object)" is null
15:00:15:365 [ERROR] 	at com.microsoft.model.StubPackageToc.addUncategorized(StubPackageToc.java:36)
15:00:15:365 [ERROR] 	at com.microsoft.build.ClassBuilder.buildFilesForStubPackage(ClassBuilder.java:152)
15:00:15:365 [ERROR] 	at com.microsoft.build.ClassBuilder.buildFilesForPackage(ClassBuilder.java:78)
15:00:15:365 [ERROR] 	at com.microsoft.build.YmlFilesBuilder$Processor.buildPackage(YmlFilesBuilder.java:208)
15:00:15:365 [ERROR] 	at com.microsoft.build.YmlFilesBuilder$Processor.lambda$buildPackage$1(YmlFilesBuilder.java:214)
15:00:15:365 [ERROR] 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
15:00:15:365 [ERROR] 	at com.microsoft.build.YmlFilesBuilder$Processor.buildPackage(YmlFilesBuilder.java:214)
15:00:15:365 [ERROR] 	at com.microsoft.build.YmlFilesBuilder$Processor.process(YmlFilesBuilder.java:157)
15:00:15:365 [ERROR] 	at com.microsoft.build.YmlFilesBuilder.build(YmlFilesBuilder.java:88)
15:00:15:365 [ERROR] 	at com.microsoft.doclet.DocFxDoclet.run(DocFxDoclet.java:57)
15:00:15:365 [ERROR] 	at jdk.javadoc/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:556)
15:00:15:365 [ERROR] 	at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:393)
15:00:15:365 [ERROR] 	at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:342)
15:00:15:365 [ERROR] 	at jdk.javadoc/jdk.javadoc.internal.tool.Main.execute(Main.java:63)
15:00:15:365 [ERROR] 	at jdk.javadoc/jdk.javadoc.internal.tool.Main.main(Main.java:52)
```

The `Uncategorized` section in the StubToc was not initialized, causing this error. This resolves it (confirmed by testing it with bigquerystorage).