### PR TITLE
feat: refactor Version selection

### DIFF
--- a/third_party/docfx-doclet-143274/pom.xml
+++ b/third_party/docfx-doclet-143274/pom.xml
@@ -94,9 +94,9 @@
       </plugin>
 
       <plugin>
-        <groupId>com.coveo</groupId>
+        <groupId>com.spotify.fmt</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.13</version>
+        <version>2.23</version>
         <configuration>
           <style>google</style>
           <verbose>true</verbose>

--- a/third_party/docfx-doclet-143274/src/main/java/com/google/docfx/doclet/RepoMetadata.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/google/docfx/doclet/RepoMetadata.java
@@ -46,6 +46,9 @@ public class RepoMetadata {
   @SerializedName("api_id")
   private String apiId;
 
+  @SerializedName("recommended_package")
+  private String recommendedPackage;
+
   private String artifactId;
 
   public String getNamePretty() {
@@ -78,6 +81,10 @@ public class RepoMetadata {
 
   public void setProductDocumentationUri(String productDocumentationUri) {
     this.productDocumentationUri = productDocumentationUri;
+  }
+
+  public Optional<String> getRecommendedPackage() {
+    return Optional.ofNullable(this.recommendedPackage);
   }
 
   public String getApiDescription() {

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageBuilder.java
@@ -35,7 +35,7 @@ class PackageBuilder {
       PackageElement packageElement,
       RepoMetadata repoMetadata,
       String artifactVersion,
-      String recommendedApiVersion) {
+      String recommendedPackage) {
     String status = packageLookup.extractStatus(packageElement);
     String fileName = packageElement.getQualifiedName() + ".md";
     PackageOverviewFile packageOverviewFile =
@@ -48,7 +48,7 @@ class PackageBuilder {
             packageLookup,
             referenceBuilder,
             artifactVersion,
-            recommendedApiVersion);
+            recommendedPackage);
     return packageOverviewFile;
   }
 }

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageOverviewFile.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageOverviewFile.java
@@ -55,9 +55,12 @@ public class PackageOverviewFile {
   // This is only set if the package is not a GA package
   private String PRERELEASE_IMPLICATIONS = "";
 
-  private String recommendedApiVersion;
+  // Uses the `recommended_package` field set in the RepoMetadata file if set; otherwise computes it.
+  private String recommendedPackage;
 
-  // This is only set if the package is not the latest GA package
+  private String recommendedPackageLink;
+
+  // This is only set if the package is not the recommended package
   private String RECOMMENDED_VERSION = "";
 
   // This is only set if the package is a stub package
@@ -81,19 +84,18 @@ public class PackageOverviewFile {
       PackageLookup packageLookup,
       ReferenceBuilder referenceBuilder,
       String artifactVersion,
-      String recommendedApiVersion) {
+      String recommendedPackage) {
     this.outputPath = outputPath;
     this.fileName = fileName;
     this.packageElement = packageElement;
-    this.recommendedApiVersion = recommendedApiVersion;
+    this.recommendedPackage = recommendedPackage;
 
     String packageURIPath = fileName.replace(".md", "");
 
     this.PACKAGE_HEADER = "# Package " + packageURIPath + " (" + artifactVersion + ")\n";
 
-    // This will always link to the latest version of the package classes
     String cloudRADChildElementLinkPrefix =
-        "https://cloud.google.com/java/docs/reference/" + repoMetadata.getArtifactId() + "/latest/";
+        "https://cloud.google.com/java/docs/reference/" + repoMetadata.getArtifactId() + "/" + artifactVersion + "/";
 
     String packageURIPathGithub = packageURIPath.replace('.', '/');
     String githubSourcePackageLink =
@@ -103,56 +105,40 @@ public class PackageOverviewFile {
             + "/src/main/java/"
             + packageURIPathGithub;
 
+    String cgcRootUri = "https://cloud.google.com/java/docs/reference/";
+    this.recommendedPackageLink = cgcRootUri + repoMetadata.getArtifactId() + "/" + artifactVersion + "/" + this.recommendedPackage;
     // If the package status is not a GA version, then add a disclaimer around prerelease
     // implications
     if (status != null) {
       this.PRERELEASE_IMPLICATIONS =
           "## Prerelease Implications\n\n"
-              + "This package is a prerelease version! Use with caution.\n"
-              + "Prerelease versions are considered unstable as they may be shut down. You can read more about [Cloud API versioning strategy here](https://cloud.google.com/apis/design/versioning).\n"
-              + "Each Cloud Java client library may contain multiple packages. Each package containing a version number in its name corresponds to a published version of the service.\n"
-              + "We recommend using the latest stable version for new production applications, which can be identified by the largest numeric version that does not contain a suffix.\n"
-              + "For example, if a client library has two packages: `v1` and `v2alpha`, then the latest stable version is `v1`.\n"
-              + "If you use an unstable release, breaking changes may be introduced when upgrading.\n\n";
+              + "This package is a prerelease version! Use with caution.\n\n"
+              + "Prerelease versions are considered unstable as they may be shut down and/or subject to breaking changes when upgrading.\n"
+              + "Use them only for testing or if you specifically need their experimental features.\n\n";
     }
 
-    // This regex captures the package path before the version (if it exists) and the version
-    Pattern pattern = Pattern.compile("(.*?)(v\\d+.*?)(?:\\.|$)");
-    ImmutableList<Object> packageVersionURIInfo =
-        extractPackageBaseURIBeforeVersion(packageURIPath, pattern);
-    String basePackageURI = packageVersionURIInfo.get(0).toString();
-    String packageVersion = packageVersionURIInfo.get(1).toString();
-    // Build link to the Cloud RAD link for the recommended package
-    String recommendedPackageVersionLink =
-        cloudRADChildElementLinkPrefix + basePackageURI + recommendedApiVersion;
-
-    // A package is not the latest GA version if it is a prerelease version, or if it is a GA
-    // version that is not the same as the recommended Api version
-    if (basePackageURI != "N/A") {
-      if (status != null || (!packageVersion.equals(this.recommendedApiVersion))) {
+    // If a package is not the same as the recommended package, add a disclaimer. If the recommended package does not exist, then do not set the disclaimer.
+    if (!this.recommendedPackage.isEmpty() && !packageElement.getQualifiedName().toString().equals(this.recommendedPackage)) {
         this.RECOMMENDED_VERSION =
-            "## This package is not the latest GA version! \n\n"
-                + " For this library, we recommend using the [package]("
-                + recommendedPackageVersionLink
+            "## This package is not the recommended entry point to using this client library!\n\n"
+                + " For this library, we recommend using ["
+                + recommendedPackage
+                + "]("
+                + recommendedPackageLink
                 + ")"
-                + " associated with API version "
-                + this.recommendedApiVersion
                 + " for new applications.\n"
                 + "\n";
-      }
     }
 
-    // If recommended version package URI exists, link to it for the Stub class as well
-    if (basePackageURI != "N/A"
-        && String.valueOf(this.packageElement.getQualifiedName()).contains("stub")) {
+    // Link to recommended package (if it exists) for the Stub class as well
+    if (!this.recommendedPackage.isEmpty() && String.valueOf(this.packageElement.getQualifiedName()).contains("stub")) {
       this.STUB_IMPLICATIONS =
           "## Stub Package Implications\n\n"
               + "This package is a a base stub class. It is for advanced usage and reflects the underlying API directly.\n"
-              + "We generally recommend using non-stub, latest GA package, such as ["
-              + basePackageURI
-              + recommendedApiVersion
+              + "We generally recommend using the non-stub, latest GA package, such as ["
+              + recommendedPackage
               + "]("
-              + recommendedPackageVersionLink
+              + recommendedPackageLink
               + ")"
               + ". Use with caution.\n";
     } else if (String.valueOf(this.packageElement.getQualifiedName()).contains("stub")) {

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageOverviewFile.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/PackageOverviewFile.java
@@ -55,7 +55,8 @@ public class PackageOverviewFile {
   // This is only set if the package is not a GA package
   private String PRERELEASE_IMPLICATIONS = "";
 
-  // Uses the `recommended_package` field set in the RepoMetadata file if set; otherwise computes it.
+  // Uses the `recommended_package` field set in the RepoMetadata file if set; otherwise computes
+  // it.
   private String recommendedPackage;
 
   private String recommendedPackageLink;
@@ -95,7 +96,11 @@ public class PackageOverviewFile {
     this.PACKAGE_HEADER = "# Package " + packageURIPath + " (" + artifactVersion + ")\n";
 
     String cloudRADChildElementLinkPrefix =
-        "https://cloud.google.com/java/docs/reference/" + repoMetadata.getArtifactId() + "/" + artifactVersion + "/";
+        "https://cloud.google.com/java/docs/reference/"
+            + repoMetadata.getArtifactId()
+            + "/"
+            + artifactVersion
+            + "/";
 
     String packageURIPathGithub = packageURIPath.replace('.', '/');
     String githubSourcePackageLink =
@@ -106,7 +111,13 @@ public class PackageOverviewFile {
             + packageURIPathGithub;
 
     String cgcRootUri = "https://cloud.google.com/java/docs/reference/";
-    this.recommendedPackageLink = cgcRootUri + repoMetadata.getArtifactId() + "/" + artifactVersion + "/" + this.recommendedPackage;
+    this.recommendedPackageLink =
+        cgcRootUri
+            + repoMetadata.getArtifactId()
+            + "/"
+            + artifactVersion
+            + "/"
+            + this.recommendedPackage;
     // If the package status is not a GA version, then add a disclaimer around prerelease
     // implications
     if (status != null) {
@@ -117,21 +128,24 @@ public class PackageOverviewFile {
               + "Use them only for testing or if you specifically need their experimental features.\n\n";
     }
 
-    // If a package is not the same as the recommended package, add a disclaimer. If the recommended package does not exist, then do not set the disclaimer.
-    if (!this.recommendedPackage.isEmpty() && !packageElement.getQualifiedName().toString().equals(this.recommendedPackage)) {
-        this.RECOMMENDED_VERSION =
-            "## This package is not the recommended entry point to using this client library!\n\n"
-                + " For this library, we recommend using ["
-                + recommendedPackage
-                + "]("
-                + recommendedPackageLink
-                + ")"
-                + " for new applications.\n"
-                + "\n";
+    // If a package is not the same as the recommended package, add a disclaimer. If the recommended
+    // package does not exist, then do not set the disclaimer.
+    if (!this.recommendedPackage.isEmpty()
+        && !packageElement.getQualifiedName().toString().equals(this.recommendedPackage)) {
+      this.RECOMMENDED_VERSION =
+          "## This package is not the recommended entry point to using this client library!\n\n"
+              + " For this library, we recommend using ["
+              + recommendedPackage
+              + "]("
+              + recommendedPackageLink
+              + ")"
+              + " for new applications.\n"
+              + "\n";
     }
 
     // Link to recommended package (if it exists) for the Stub class as well
-    if (!this.recommendedPackage.isEmpty() && String.valueOf(this.packageElement.getQualifiedName()).contains("stub")) {
+    if (!this.recommendedPackage.isEmpty()
+        && String.valueOf(this.packageElement.getQualifiedName()).contains("stub")) {
       this.STUB_IMPLICATIONS =
           "## Stub Package Implications\n\n"
               + "This package is a a base stub class. It is for advanced usage and reflects the underlying API directly.\n"

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/YmlFilesBuilder.java
@@ -20,7 +20,6 @@ import com.microsoft.util.ElementUtil;
 import com.microsoft.util.FileUtil;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -148,19 +147,20 @@ public class YmlFilesBuilder {
                   .filter(pkg -> !packageLookup.isApiVersionStubPackage(pkg))
                   .collect(Collectors.toList()));
 
-      // Calculate the recommended package based on the latest stable Version ID. This will be overridden by the recommended_package in the RepoMetadata, if set
+      // Calculate the recommended package based on the latest stable Version ID. This will be
+      // overridden by the recommended_package in the RepoMetadata, if set
       HashMap<ApiVersion, String> packageVersions = new HashMap<>();
       for (PackageElement pkg : allPackages) {
         Optional<ApiVersion> apiVersion = packageLookup.extractApiVersion(pkg);
-        apiVersion.ifPresent(version -> packageVersions.put(version, String.valueOf(pkg.getQualifiedName())));
+        apiVersion.ifPresent(
+            version -> packageVersions.put(version, String.valueOf(pkg.getQualifiedName())));
       }
 
       // If repoMetadata contains a recommended package, use that instead of the calculated package
       Optional<String> inputRecommendedPackage = repoMetadata.getRecommendedPackage();
-      if(inputRecommendedPackage.isPresent()){
+      if (inputRecommendedPackage.isPresent()) {
         recommendedPackage = repoMetadata.getRecommendedPackage().get();
-      }
-      else if(!packageVersions.keySet().isEmpty()){
+      } else if (!packageVersions.keySet().isEmpty()) {
         recommendedApiVersion = ApiVersion.getRecommended(packageVersions.keySet());
         recommendedPackage = packageVersions.get(recommendedApiVersion).toString();
       }

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/LibraryOverviewFile.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/LibraryOverviewFile.java
@@ -17,22 +17,24 @@ public class LibraryOverviewFile {
   // This is passed in as an environment variable
   private String librariesBomVersion;
 
-  // This is parsed from the packages
-  private String recommendedApiVersion;
+  private String recommendedPackageLink;
 
-  private String LIBRARY_OVERVIEW_FILE_HEADER;
+  // This is parsed from the .repoMetadata.json if it exists, or is calculated in ApiVersion
+  private String recommendedPackage;
 
-  private String LIBRARY_OVERVIEW_KEY_REFERENCE_HEADER;
+  private String LIBRARY_OVERVIEW_FILE_HEADER = "";
 
-  private String LIBRARY_OVERVIEW_KEY_REFERENCE_TABLE;
+  private String LIBRARY_OVERVIEW_KEY_REFERENCE_HEADER = "";
 
-  private String LIBRARY_OVERVIEW_GETTING_STARTED_SECTION;
+  private String LIBRARY_OVERVIEW_KEY_REFERENCE_TABLE = "";
 
-  private String LIBRARY_OVERVIEW_CLIENT_INSTALLATION_SECTION;
+  private String LIBRARY_OVERVIEW_GETTING_STARTED_SECTION = "";
 
-  private String LIBRARY_OVERVIEW_CLIENT_INSTALLATION_HEADER;
+  private String LIBRARY_OVERVIEW_CLIENT_INSTALLATION_SECTION = "";
 
-  private String LIBRARY_OVERVIEW_PACKAGE_SELECTION_SECTION;
+  private String LIBRARY_OVERVIEW_CLIENT_INSTALLATION_HEADER = "";
+
+  private String LIBRARY_OVERVIEW_PACKAGE_SELECTION_SECTION = "";
 
   public LibraryOverviewFile(
       String outputPath,
@@ -40,16 +42,23 @@ public class LibraryOverviewFile {
       String artifactVersion,
       String librariesBomVersion,
       String repoMetadataFilePath,
-      String recommendedApiVersion) {
+      String recommendedPackage) {
     this.outputPath = outputPath;
     this.fileName = fileName;
     this.artifactVersion = artifactVersion;
     this.librariesBomVersion = librariesBomVersion;
     this.repoMetadataFilePath = repoMetadataFilePath;
-    this.recommendedApiVersion = recommendedApiVersion;
+    this.recommendedPackage = recommendedPackage;
 
     RepoMetadata repoMetadata = new RepoMetadata();
     repoMetadata = repoMetadata.parseRepoMetadata(this.repoMetadataFilePath);
+
+    this.recommendedPackageLink = "";
+    // Compute the link to the recommended package if it exists
+    if(!this.recommendedPackage.isEmpty()){
+      String cgcRootUri = "https://cloud.google.com/java/docs/reference/";
+      this.recommendedPackageLink = cgcRootUri + repoMetadata.getArtifactId() + "/" + artifactVersion + "/" + this.recommendedPackage;
+    }
 
     this.LIBRARY_OVERVIEW_FILE_HEADER =
         "# " + repoMetadata.getArtifactId() + " overview (" + artifactVersion + ")\n\n";
@@ -81,6 +90,7 @@ public class LibraryOverviewFile {
             + "\n\n";
 
     // For non-service libraries, these steps are not necessary
+    // TODO: https://github.com/googleapis/java-docfx-doclet/issues/253 : Ideally we can refactor for custom modules to copy from their README sections
     String[] runtimeLibraries = {"gax", "api-common", "common-protos", "google-cloud-core"};
 
     if (Arrays.asList(runtimeLibraries).contains(repoMetadata.getApiShortName())) {
@@ -101,109 +111,122 @@ public class LibraryOverviewFile {
               + repoMetadata.getApiShortName()
               + ".googleapis.com)\n"
               + "- [Set up authentication](https://cloud.google.com/docs/authentication/client-libraries)\n\n";
+
+      this.LIBRARY_OVERVIEW_CLIENT_INSTALLATION_HEADER =
+          "## Use the "
+              + repoMetadata.getNamePretty()
+              + " for Java\n"
+              + "To ensure that your project uses compatible versions of the libraries\n"
+              + "and their component artifacts, import `com.google.cloud:libraries-bom` and use\n"
+              + "the BOM to specify dependency versions.  Be sure to remove any versions that you\n"
+              + "set previously. For more information about\n"
+              + "BOMs, see [Google Cloud Platform Libraries BOM](https://cloud.google.com/java/docs/bom).\n\n";
+
+      // When b/312765900 is implemented, then refactor this section to use the devsite-selector
+      // format. Current format is a workaround so the sanitizer doesn't remove the content.
+      this.LIBRARY_OVERVIEW_CLIENT_INSTALLATION_SECTION =
+          "### Maven\n"
+              + "Import the BOM in the <code>dependencyManagement</code> section of your <code>pom.xml</code> file.\n"
+              + "Include specific artifacts you depend on in the <code>dependencies</code> section, but don't\n"
+              + "specify the artifacts' versions in the <code>dependencies</code> section.\n"
+              + "\n"
+              + "The example below demonstrates how you would import the BOM and include the <code>"
+              + repoMetadata.getArtifactId()
+              + "</code> artifact.\n"
+              + "<pre class=\"prettyprint lang-xml devsite-click-to-copy\">\n"
+              + "&lt;dependencyManagement&gt;\n"
+              + " &lt;dependencies&gt;\n"
+              + "   &lt;dependency&gt;\n"
+              + "      &lt;groupId&gt;com.google.cloud&lt;/groupId&gt;\n"
+              + "      &lt;artifactId&gt;libraries-bom&lt;/artifactId&gt;\n"
+              + "      &lt;version&gt;"
+              + this.librariesBomVersion
+              + "&lt;/version&gt;\n"
+              + "      &lt;type&gt;pom&lt;/type&gt;\n"
+              + "      &lt;scope&gt;import&lt;/scope&gt;\n"
+              + "   &lt;/dependency&gt;\n"
+              + " &lt;/dependencies&gt;\n"
+              + "&lt;/dependencyManagement&gt;\n\n"
+              + "&lt;dependencies&gt;\n"
+              + " &lt;dependency&gt;\n"
+              + "   &lt;groupId&gt;com.google.cloud&lt;/groupId&gt;\n"
+              + "   &lt;artifactId&gt;"
+              + repoMetadata.getArtifactId()
+              + "&lt;/artifactId&gt;\n"
+              + " &lt;/dependency&gt;\n"
+              + "&lt;/dependencies&gt;\n"
+              + "</pre>\n\n"
+              + "### Gradle\n"
+              + "BOMs are supported by default in Gradle 5.x or later. Add a <code>platform</code>\n"
+              + "dependency on <code>com.google.cloud:libraries-bom</code> and remove the version from the\n"
+              + "dependency declarations in the artifact's <code>build.gradle</code> file.\n"
+              + "\n"
+              + "The example below demonstrates how you would import the BOM and include the <code>"
+              + repoMetadata.getArtifactId()
+              + "</code> artifact.\n"
+              + "<pre class=\"prettyprint lang-Groovy devsite-click-to-copy\">\n"
+              + "implementation platform(&#39;com.google.cloud:libraries-bom:"
+              + librariesBomVersion
+              + "&#39;)\n"
+              + "implementation &#39;"
+              + repoMetadata.getDistributionName()
+              + "&#39;\n"
+              + "</pre>\n\n"
+              + "The <code>platform</code> and <code>enforcedPlatform</code> keywords supply dependency versions\n"
+              + "declared in a BOM. The <code>enforcedPlatform</code> keyword enforces the dependency\n"
+              + "versions declared in the BOM and thus overrides what you specified.\n\n"
+              + "For more details of the <code>platform</code> and <code>enforcedPlatform</code> keywords Gradle 5.x or higher, see\n"
+              + "[Gradle: Importing Maven BOMs](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import).\n"
+              + "\n"
+              + "If you're using Gradle 4.6 or later, add\n"
+              + "<code>enableFeaturePreview('IMPROVED_POM_SUPPORT')</code> to your <code>settings.gradle</code> file. For details, see\n"
+              + "[Gradle 4.6 Release Notes: BOM import](https://docs.gradle.org/4.6/release-notes.html#bom-import).\n"
+              + "Versions of Gradle earlier than 4.6 don't support BOMs.</p>\n\n"
+              + "### SBT\n"
+              + "SBT [doesn't support BOMs](https://github.com/sbt/sbt/issues/4531). You can find\n"
+              + "recommended versions of libraries from a particular BOM version on the\n"
+              + "[dashboard](https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/index.html)\n"
+              + "and set the versions manually.\n"
+              + "To use the latest version of this library, add this to your dependencies:\n"
+              + "<pre class=\"prettyprint lang-Scala devsite-click-to-copy\">\n"
+              + "libraryDependencies += &quot;com.google.cloud&quot; % &quot;"
+              + repoMetadata.getArtifactId()
+              + "&quot; % &quot;"
+              + artifactVersion
+              + "&quot;\n"
+              + "</pre>\n\n";
+
     }
-
-    this.LIBRARY_OVERVIEW_CLIENT_INSTALLATION_HEADER =
-        "## Use the "
-            + repoMetadata.getNamePretty()
-            + " for Java\n"
-            + "To ensure that your project uses compatible versions of the libraries\n"
-            + "and their component artifacts, import `com.google.cloud:libraries-bom` and use\n"
-            + "the BOM to specify dependency versions.  Be sure to remove any versions that you\n"
-            + "set previously. For more information about\n"
-            + "BOMs, see [Google Cloud Platform Libraries BOM](https://cloud.google.com/java/docs/bom).\n\n";
-
-    // When b/312765900 is implemented, then refactor this section to use the devsite-selector
-    // format. Current format is a workaround so the sanitizer doesn't remove the content.
-    this.LIBRARY_OVERVIEW_CLIENT_INSTALLATION_SECTION =
-        "### Maven\n"
-            + "Import the BOM in the <code>dependencyManagement</code> section of your <code>pom.xml</code> file.\n"
-            + "Include specific artifacts you depend on in the <code>dependencies</code> section, but don't\n"
-            + "specify the artifacts' versions in the <code>dependencies</code> section.\n"
-            + "\n"
-            + "The example below demonstrates how you would import the BOM and include the <code>"
-            + repoMetadata.getArtifactId()
-            + "</code> artifact.\n"
-            + "<pre class=\"prettyprint lang-xml devsite-click-to-copy\">\n"
-            + "&lt;dependencyManagement&gt;\n"
-            + " &lt;dependencies&gt;\n"
-            + "   &lt;dependency&gt;\n"
-            + "      &lt;groupId&gt;com.google.cloud&lt;/groupId&gt;\n"
-            + "      &lt;artifactId&gt;libraries-bom&lt;/artifactId&gt;\n"
-            + "      &lt;version&gt;"
-            + this.librariesBomVersion
-            + "&lt;/version&gt;\n"
-            + "      &lt;type&gt;pom&lt;/type&gt;\n"
-            + "      &lt;scope&gt;import&lt;/scope&gt;\n"
-            + "   &lt;/dependency&gt;\n"
-            + " &lt;/dependencies&gt;\n"
-            + "&lt;/dependencyManagement&gt;\n\n"
-            + "&lt;dependencies&gt;\n"
-            + " &lt;dependency&gt;\n"
-            + "   &lt;groupId&gt;com.google.cloud&lt;/groupId&gt;\n"
-            + "   &lt;artifactId&gt;"
-            + repoMetadata.getArtifactId()
-            + "&lt;/artifactId&gt;\n"
-            + " &lt;/dependency&gt;\n"
-            + "&lt;/dependencies&gt;\n"
-            + "</pre>\n\n"
-            + "### Gradle\n"
-            + "BOMs are supported by default in Gradle 5.x or later. Add a <code>platform</code>\n"
-            + "dependency on <code>com.google.cloud:libraries-bom</code> and remove the version from the\n"
-            + "dependency declarations in the artifact's <code>build.gradle</code> file.\n"
-            + "\n"
-            + "The example below demonstrates how you would import the BOM and include the <code>"
-            + repoMetadata.getArtifactId()
-            + "</code> artifact.\n"
-            + "<pre class=\"prettyprint lang-Groovy devsite-click-to-copy\">\n"
-            + "implementation platform(&#39;com.google.cloud:libraries-bom:"
-            + librariesBomVersion
-            + "&#39;)\n"
-            + "implementation &#39;"
-            + repoMetadata.getDistributionName()
-            + "&#39;\n"
-            + "</pre>\n\n"
-            + "The <code>platform</code> and <code>enforcedPlatform</code> keywords supply dependency versions\n"
-            + "declared in a BOM. The <code>enforcedPlatform</code> keyword enforces the dependency\n"
-            + "versions declared in the BOM and thus overrides what you specified.\n\n"
-            + "For more details of the <code>platform</code> and <code>enforcedPlatform</code> keywords Gradle 5.x or higher, see\n"
-            + "[Gradle: Importing Maven BOMs](https://docs.gradle.org/current/userguide/platforms.html#sub:bom_import).\n"
-            + "\n"
-            + "If you're using Gradle 4.6 or later, add\n"
-            + "<code>enableFeaturePreview('IMPROVED_POM_SUPPORT')</code> to your <code>settings.gradle</code> file. For details, see\n"
-            + "[Gradle 4.6 Release Notes: BOM import](https://docs.gradle.org/4.6/release-notes.html#bom-import).\n"
-            + "Versions of Gradle earlier than 4.6 don't support BOMs.</p>\n\n"
-            + "### SBT\n"
-            + "SBT [doesn't support BOMs](https://github.com/sbt/sbt/issues/4531). You can find\n"
-            + "recommended versions of libraries from a particular BOM version on the\n"
-            + "[dashboard](https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/index.html)\n"
-            + "and set the versions manually.\n"
-            + "To use the latest version of this library, add this to your dependencies:\n"
-            + "<pre class=\"prettyprint lang-Scala devsite-click-to-copy\">\n"
-            + "libraryDependencies += &quot;com.google.cloud&quot; % &quot;"
-            + repoMetadata.getArtifactId()
-            + "&quot; % &quot;"
-            + artifactVersion
-            + "&quot;\n"
-            + "</pre>\n\n";
-
-    // Some client libraries do not have an underlying API service (e.g.
-    // google-cloud-logging-logback, google-cloud-storage-nio, google-cloud-spanner-jdbc), hence
-    // there is no recommended API version.
-    if (this.recommendedApiVersion.isEmpty()) {
+    // It should be very rare that a client library does not have a recommended package
+    if (this.recommendedPackage.isEmpty()) {
       this.LIBRARY_OVERVIEW_PACKAGE_SELECTION_SECTION = "";
     } else {
       this.LIBRARY_OVERVIEW_PACKAGE_SELECTION_SECTION =
-          "## Which version should I use?\n"
-              + "For this library, we recommend using API version "
-              + this.recommendedApiVersion
-              + " for new applications.\n"
-              + "\n"
-              + "Each Cloud Java client library may contain multiple packages. Each package containing a version number in its name corresponds to a published version of the service.\n"
-              + "We recommend using the latest stable version for new production applications, which can be identified by the largest numeric version that does not contain a suffix.\n"
-              + "For example, if a client library has two packages: `v1` and `v2alpha`, then the latest stable version is `v1`.\n"
-              + "If you use an unstable release, breaking changes may be introduced when upgrading.\n"
-              + "You can read more about [Cloud API versioning strategy here](https://cloud.google.com/apis/design/versioning).\n\n";
+          "## Which version ID should I get started with?\n"
+              + "For this library, we recommend using "
+              + "["
+              + this.recommendedPackage
+              + "]("
+              + this.recommendedPackageLink
+              + ") for new applications.\n\n"
+              + "### Understanding Version ID and Library Versions\n"
+              + "When using a Cloud client library, it's important to distinguish between two types of versions:\n"
+              + "- **Library Version**: The version of the software package (the client library) that helps you interact with the Cloud service. These libraries are\n"
+              + "released and updated frequently with bug fixes, improvements, and support for new service features and versions. The version selector at\n"
+              + "the top of this page represents the client library version.\n"
+              + "- **Version ID**: The version of the Cloud service itself (e.g. "
+              + repoMetadata.getNamePretty()
+              + "). New Version IDs are introduced infrequently, and often involve\n"
+              + "changes to the core functionality and structure of the Cloud service itself. The packages in the lefthand navigation represent packages tied\n"
+              + "to a specific Version ID of the Cloud service.\n\n"
+              + "### Managing Library Versions\n"
+              + "We recommend using the <code>com.google.cloud:libraries-bom</code> installation method detailed above to streamline dependency management\n"
+              + "across multiple Cloud Java client libraries. This ensures compatibility and simplifies updates.\n\n"
+              + "### Choosing the Right Version ID\n"
+              + "Each Cloud Java client library may contain packages tied to specific Version IDs (e.g., <code>v1</code>, <code>v2alpha</code>). For new production applications, use\n"
+              + "the latest stable Version ID. This is identified by the highest version number **without** a suffix (like \"alpha\" or \"beta\"). You can read more about\n"
+              + "[Cloud API versioning strategy here](https://cloud.google.com/apis/design/versioning).\n\n"
+              + "**Important**: Unstable Version ID releases (those _with_ suffixes) are subject to breaking changes when upgrading. Use them only for testing or if you specifically need their experimental features.\n\n";
     }
   }
 

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/LibraryOverviewFile.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/LibraryOverviewFile.java
@@ -55,9 +55,15 @@ public class LibraryOverviewFile {
 
     this.recommendedPackageLink = "";
     // Compute the link to the recommended package if it exists
-    if(!this.recommendedPackage.isEmpty()){
+    if (!this.recommendedPackage.isEmpty()) {
       String cgcRootUri = "https://cloud.google.com/java/docs/reference/";
-      this.recommendedPackageLink = cgcRootUri + repoMetadata.getArtifactId() + "/" + artifactVersion + "/" + this.recommendedPackage;
+      this.recommendedPackageLink =
+          cgcRootUri
+              + repoMetadata.getArtifactId()
+              + "/"
+              + artifactVersion
+              + "/"
+              + this.recommendedPackage;
     }
 
     this.LIBRARY_OVERVIEW_FILE_HEADER =
@@ -90,7 +96,8 @@ public class LibraryOverviewFile {
             + "\n\n";
 
     // For non-service libraries, these steps are not necessary
-    // TODO: https://github.com/googleapis/java-docfx-doclet/issues/253 : Ideally we can refactor for custom modules to copy from their README sections
+    // TODO: https://github.com/googleapis/java-docfx-doclet/issues/253 : Ideally we can refactor
+    // for custom modules to copy from their README sections
     String[] runtimeLibraries = {"gax", "api-common", "common-protos", "google-cloud-core"};
 
     if (Arrays.asList(runtimeLibraries).contains(repoMetadata.getApiShortName())) {
@@ -195,7 +202,6 @@ public class LibraryOverviewFile {
               + artifactVersion
               + "&quot;\n"
               + "</pre>\n\n";
-
     }
     // It should be very rare that a client library does not have a recommended package
     if (this.recommendedPackage.isEmpty()) {

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.agreements.md
@@ -7,6 +7,10 @@
    </tr>
  </table>
 
+## This package is not the recommended entry point to using this client library!
+
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
+
 ## Classes
 <table>
    <tr>
@@ -15,7 +19,7 @@ Class</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations">com.microsoft.samples.agreements.AgreementDetailsCollectionOperations</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.agreements.AgreementDetailsCollectionOperations">com.microsoft.samples.agreements.AgreementDetailsCollectionOperations</a></td>
 <td>
 
 <strong>Deprecated.</strong> <em>Use <xref uid="AgreementMetaData" data-throw-if-not-resolved="false">AgreementMetaData</xref> instead.</em>
@@ -23,13 +27,13 @@ Description</th>
 Agreement details collection operations implementation class.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.agreements.AgreementMetaData">com.microsoft.samples.agreements.AgreementMetaData</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.agreements.AgreementMetaData">com.microsoft.samples.agreements.AgreementMetaData</a></td>
 <td>
 The AgreementMetaData provides metadata about the agreement type that partner can provide
  confirmation of customer acceptance.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.agreements.ResourceCollection">com.microsoft.samples.agreements.ResourceCollection</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.agreements.ResourceCollection">com.microsoft.samples.agreements.ResourceCollection</a></td>
 <td>
 Contains a collection of resources with JSON properties to represent the output Type of objects
  in collection</td>
@@ -44,7 +48,7 @@ Interface</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.agreements.IAgreementDetailsCollection">com.microsoft.samples.agreements.IAgreementDetailsCollection</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.agreements.IAgreementDetailsCollection">com.microsoft.samples.agreements.IAgreementDetailsCollection</a></td>
 <td>
 
 <strong>Deprecated.</strong> <em>This one is deprecated :(</em>

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.commentinheritance.md
@@ -7,6 +7,10 @@
    </tr>
  </table>
 
+## This package is not the recommended entry point to using this client library!
+
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
+
 ## Classes
 <table>
    <tr>
@@ -15,22 +19,22 @@ Class</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Animal">com.microsoft.samples.commentinheritance.Animal</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Animal">com.microsoft.samples.commentinheritance.Animal</a></td>
 <td>
 Animal.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Dog">com.microsoft.samples.commentinheritance.Dog</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Dog">com.microsoft.samples.commentinheritance.Dog</a></td>
 <td>
 Canine and man's best friend.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Herbivorous.Plant">com.microsoft.samples.commentinheritance.Herbivorous.Plant</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Herbivorous.Plant">com.microsoft.samples.commentinheritance.Herbivorous.Plant</a></td>
 <td>
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Mammal">com.microsoft.samples.commentinheritance.Mammal</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Mammal">com.microsoft.samples.commentinheritance.Mammal</a></td>
 <td>
 Mammal.</td>
    </tr>
@@ -44,27 +48,27 @@ Interface</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Carnivorous">com.microsoft.samples.commentinheritance.Carnivorous</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Carnivorous">com.microsoft.samples.commentinheritance.Carnivorous</a></td>
 <td>
 Marks an Animal that eats other animals.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Herbivorous">com.microsoft.samples.commentinheritance.Herbivorous</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Herbivorous">com.microsoft.samples.commentinheritance.Herbivorous</a></td>
 <td>
 Marks animals that eat plants.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Omnivorous">com.microsoft.samples.commentinheritance.Omnivorous</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Omnivorous">com.microsoft.samples.commentinheritance.Omnivorous</a></td>
 <td>
 Eats plants and animals.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Organism">com.microsoft.samples.commentinheritance.Organism</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Organism">com.microsoft.samples.commentinheritance.Organism</a></td>
 <td>
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.commentinheritance.Viviparous">com.microsoft.samples.commentinheritance.Viviparous</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.commentinheritance.Viviparous">com.microsoft.samples.commentinheritance.Viviparous</a></td>
 <td>
 Mammals that give birth to young that develop within the mother's body.</td>
    </tr>

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.md
@@ -7,6 +7,10 @@
    </tr>
  </table>
 
+## This package is not the recommended entry point to using this client library!
+
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
+
 ## Client Classes
 Client classes are the main entry point to using a package.
 They contain several variations of Java methods for each of the API's methods.
@@ -17,7 +21,7 @@ Client</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.SpeechClient">com.microsoft.samples.google.SpeechClient</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.SpeechClient">com.microsoft.samples.google.SpeechClient</a></td>
 <td>
 Service Description: Service that implements Google Cloud Speech API.
 
@@ -35,7 +39,7 @@ Settings</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.ProductSearchSettings">com.microsoft.samples.google.ProductSearchSettings</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.ProductSearchSettings">com.microsoft.samples.google.ProductSearchSettings</a></td>
 <td>
 Settings class to configure an instance of <xref uid="ProductSearchClient" data-throw-if-not-resolved="false">ProductSearchClient</xref>.
 
@@ -43,7 +47,7 @@ Settings class to configure an instance of <xref uid="ProductSearchClient" data-
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.SpeechSettings">com.microsoft.samples.google.SpeechSettings</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.SpeechSettings">com.microsoft.samples.google.SpeechSettings</a></td>
 <td>
 Settings class to configure an instance of <xref uid="SpeechClient" data-throw-if-not-resolved="false">SpeechClient</xref>.
 
@@ -60,12 +64,12 @@ Class</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.ProductSearchSettings.Builder">com.microsoft.samples.google.ProductSearchSettings.Builder</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.ProductSearchSettings.Builder">com.microsoft.samples.google.ProductSearchSettings.Builder</a></td>
 <td>
 Builder for ProductSearchSettings.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.RecognitionAudio">com.microsoft.samples.google.RecognitionAudio</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.RecognitionAudio">com.microsoft.samples.google.RecognitionAudio</a></td>
 <td>
 
  Contains audio data in the encoding specified in the <code>RecognitionConfig</code>.
@@ -73,7 +77,7 @@ Builder for ProductSearchSettings.</td>
  returns <xref uid="google.rpc.Code.INVALID_ARGUMENT" data-throw-if-not-resolved="false">google.rpc.Code.INVALID_ARGUMENT</xref>. See</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.SpeechSettings.Builder">com.microsoft.samples.google.SpeechSettings.Builder</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.SpeechSettings.Builder">com.microsoft.samples.google.SpeechSettings.Builder</a></td>
 <td>
 Builder for SpeechSettings.</td>
    </tr>
@@ -87,7 +91,7 @@ Interface</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.BetaApi">com.microsoft.samples.google.BetaApi</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.BetaApi">com.microsoft.samples.google.BetaApi</a></td>
 <td>
 Indicates a public API that can change at any time, and has no guarantee of API stability and
  backward-compatibility.
@@ -95,7 +99,7 @@ Indicates a public API that can change at any time, and has no guarantee of API 
  <p>Usage guidelines:</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.ValidationException.Supplier">com.microsoft.samples.google.ValidationException.Supplier</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.ValidationException.Supplier">com.microsoft.samples.google.ValidationException.Supplier</a></td>
 <td>
 </td>
    </tr>
@@ -109,7 +113,7 @@ Enum</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.RecognitionAudio.AudioSourceCase">com.microsoft.samples.google.RecognitionAudio.AudioSourceCase</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.RecognitionAudio.AudioSourceCase">com.microsoft.samples.google.RecognitionAudio.AudioSourceCase</a></td>
 <td>
 </td>
    </tr>
@@ -123,7 +127,7 @@ Exception</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.ValidationException">com.microsoft.samples.google.ValidationException</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.ValidationException">com.microsoft.samples.google.ValidationException</a></td>
 <td>
 Exception thrown if there is a validation problem with a path template, http config, or related
  framework methods. Comes as an illegal argument exception subclass. Allows to globally set a

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1.md
@@ -17,7 +17,7 @@ Client</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1.SpeechClient">com.microsoft.samples.google.v1.SpeechClient</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1.SpeechClient">com.microsoft.samples.google.v1.SpeechClient</a></td>
 <td>
 Service Description: Service that implements Google Cloud Speech API.
 

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1.stub.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1.stub.md
@@ -7,10 +7,14 @@
    </tr>
  </table>
 
+## This package is not the recommended entry point to using this client library!
+
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
+
 ## Stub Package Implications
 
 This package is a a base stub class. It is for advanced usage and reflects the underlying API directly.
-We generally recommend using non-stub, latest GA package, such as [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1). Use with caution.
+We generally recommend using the non-stub, latest GA package, such as [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1). Use with caution.
 ## Stub Classes
 <table>
    <tr>
@@ -19,21 +23,21 @@ Stub</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1.stub.GrpcSpeechStub">com.microsoft.samples.google.v1.stub.GrpcSpeechStub</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1.stub.GrpcSpeechStub">com.microsoft.samples.google.v1.stub.GrpcSpeechStub</a></td>
 <td>
 gRPC stub implementation for the Speech service API.
 
  <p>This class is for advanced usage and reflects the underlying API directly.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1.stub.HttpJsonSpeechStub">com.microsoft.samples.google.v1.stub.HttpJsonSpeechStub</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1.stub.HttpJsonSpeechStub">com.microsoft.samples.google.v1.stub.HttpJsonSpeechStub</a></td>
 <td>
 REST stub implementation for the Speech service API.
 
  <p>This class is for advanced usage and reflects the underlying API directly.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1.stub.SpeechStub">com.microsoft.samples.google.v1.stub.SpeechStub</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1.stub.SpeechStub">com.microsoft.samples.google.v1.stub.SpeechStub</a></td>
 <td>
 Base stub class for the Speech service API.
 
@@ -50,7 +54,7 @@ Settings</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1.stub.SpeechStubSettings">com.microsoft.samples.google.v1.stub.SpeechStubSettings</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1.stub.SpeechStubSettings">com.microsoft.samples.google.v1.stub.SpeechStubSettings</a></td>
 <td>
 Settings class to configure an instance of <xref uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStub" data-throw-if-not-resolved="false">com.google.cloud.speech.v1p1beta1.stub.SpeechStub</xref>.
 
@@ -67,7 +71,7 @@ Class</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1.stub.SpeechStubSettings.Builder">com.microsoft.samples.google.v1.stub.SpeechStubSettings.Builder</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1.stub.SpeechStubSettings.Builder">com.microsoft.samples.google.v1.stub.SpeechStubSettings.Builder</a></td>
 <td>
 Builder for SpeechStubSettings.</td>
    </tr>

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1beta.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1beta.md
@@ -7,18 +7,16 @@
    </tr>
  </table>
 
-## This package is not the latest GA version! 
+## This package is not the recommended entry point to using this client library!
 
- For this library, we recommend using the [package](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1) associated with API version v1 for new applications.
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
 
 ## Prerelease Implications
 
 This package is a prerelease version! Use with caution.
-Prerelease versions are considered unstable as they may be shut down. You can read more about [Cloud API versioning strategy here](https://cloud.google.com/apis/design/versioning).
-Each Cloud Java client library may contain multiple packages. Each package containing a version number in its name corresponds to a published version of the service.
-We recommend using the latest stable version for new production applications, which can be identified by the largest numeric version that does not contain a suffix.
-For example, if a client library has two packages: `v1` and `v2alpha`, then the latest stable version is `v1`.
-If you use an unstable release, breaking changes may be introduced when upgrading.
+
+Prerelease versions are considered unstable as they may be shut down and/or subject to breaking changes when upgrading.
+Use them only for testing or if you specifically need their experimental features.
 
 ## Client Classes
 Client classes are the main entry point to using a package.
@@ -30,7 +28,7 @@ Client</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1beta.SpeechClient">com.microsoft.samples.google.v1beta.SpeechClient</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1beta.SpeechClient">com.microsoft.samples.google.v1beta.SpeechClient</a></td>
 <td>
 Service Description: Service that implements Google Cloud Speech API.
 

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1p1alpha.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.google.v1p1alpha.md
@@ -7,18 +7,16 @@
    </tr>
  </table>
 
-## This package is not the latest GA version! 
+## This package is not the recommended entry point to using this client library!
 
- For this library, we recommend using the [package](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1) associated with API version v1 for new applications.
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
 
 ## Prerelease Implications
 
 This package is a prerelease version! Use with caution.
-Prerelease versions are considered unstable as they may be shut down. You can read more about [Cloud API versioning strategy here](https://cloud.google.com/apis/design/versioning).
-Each Cloud Java client library may contain multiple packages. Each package containing a version number in its name corresponds to a published version of the service.
-We recommend using the latest stable version for new production applications, which can be identified by the largest numeric version that does not contain a suffix.
-For example, if a client library has two packages: `v1` and `v2alpha`, then the latest stable version is `v1`.
-If you use an unstable release, breaking changes may be introduced when upgrading.
+
+Prerelease versions are considered unstable as they may be shut down and/or subject to breaking changes when upgrading.
+Use them only for testing or if you specifically need their experimental features.
 
 ## Client Classes
 Client classes are the main entry point to using a package.
@@ -30,7 +28,7 @@ Client</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.google.v1p1alpha.SpeechClient">com.microsoft.samples.google.v1p1alpha.SpeechClient</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1p1alpha.SpeechClient">com.microsoft.samples.google.v1p1alpha.SpeechClient</a></td>
 <td>
 Service Description: Service that implements Google Cloud Speech API.
 

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.md
@@ -7,6 +7,10 @@
    </tr>
  </table>
 
+## This package is not the recommended entry point to using this client library!
+
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
+
 ## Classes
 <table>
    <tr>
@@ -15,43 +19,43 @@ Class</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.BasePartnerComponent">com.microsoft.samples.BasePartnerComponent</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.BasePartnerComponent">com.microsoft.samples.BasePartnerComponent</a></td>
 <td>
 Holds common partner component properties and behavior. All components should inherit from this
  class. The context object type.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.BasePartnerComponentString">com.microsoft.samples.BasePartnerComponentString</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.BasePartnerComponentString">com.microsoft.samples.BasePartnerComponentString</a></td>
 <td>
 Holds common partner component properties and behavior. The context is string type by default.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.ExceptionHandler">com.microsoft.samples.ExceptionHandler</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.ExceptionHandler">com.microsoft.samples.ExceptionHandler</a></td>
 <td>
 Exception retry algorithm implementation used by <xref uid="RetryHelper" data-throw-if-not-resolved="false">RetryHelper</xref>.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.ExceptionHandler.Builder">com.microsoft.samples.ExceptionHandler.Builder</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.ExceptionHandler.Builder">com.microsoft.samples.ExceptionHandler.Builder</a></td>
 <td>
 ExceptionHandler builder.</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.KeyValuePair">com.microsoft.samples.KeyValuePair</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.KeyValuePair">com.microsoft.samples.KeyValuePair</a></td>
 <td>
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.Link">com.microsoft.samples.Link</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.Link">com.microsoft.samples.Link</a></td>
 <td>
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.Subpackage">com.microsoft.samples.Subpackage</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.Subpackage">com.microsoft.samples.Subpackage</a></td>
 <td>
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.SuperHero">com.microsoft.samples.SuperHero</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.SuperHero">com.microsoft.samples.SuperHero</a></td>
 <td>
 Hero is the main entity we will be using to something</td>
    </tr>
@@ -65,12 +69,12 @@ Interface</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.ExceptionHandler.Interceptor">com.microsoft.samples.ExceptionHandler.Interceptor</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.ExceptionHandler.Interceptor">com.microsoft.samples.ExceptionHandler.Interceptor</a></td>
 <td>
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.IPartner">com.microsoft.samples.IPartner</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.IPartner">com.microsoft.samples.IPartner</a></td>
 <td>
 The main entry point into using the partner SDK functionality. Represents a partner and
  encapsulates all the behavior attached to partners. Use this interface to get to the partner's
@@ -86,7 +90,7 @@ Enum</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.ExceptionHandler.Interceptor.RetryResult">com.microsoft.samples.ExceptionHandler.Interceptor.RetryResult</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.ExceptionHandler.Interceptor.RetryResult">com.microsoft.samples.ExceptionHandler.Interceptor.RetryResult</a></td>
 <td>
 </td>
    </tr>

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.offers.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.offers.md
@@ -7,6 +7,10 @@
    </tr>
  </table>
 
+## This package is not the recommended entry point to using this client library!
+
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
+
 ## Classes
 <table>
    <tr>
@@ -15,7 +19,7 @@ Class</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.offers.Offer">com.microsoft.samples.offers.Offer</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.offers.Offer">com.microsoft.samples.offers.Offer</a></td>
 <td>
 Represents a form of product availability to customer</td>
    </tr>

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/com.microsoft.samples.subpackage.md
@@ -7,6 +7,10 @@
    </tr>
  </table>
 
+## This package is not the recommended entry point to using this client library!
+
+ For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
+
 ## Classes
 <table>
    <tr>
@@ -15,7 +19,7 @@ Class</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.subpackage.Person">com.microsoft.samples.subpackage.Person</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.subpackage.Person">com.microsoft.samples.subpackage.Person</a></td>
 <td>
 Class that describes some person
 
@@ -23,12 +27,12 @@ Class that describes some person
 </td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.subpackage.Person.IdentificationInfo">com.microsoft.samples.subpackage.Person.IdentificationInfo</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.subpackage.Person.IdentificationInfo">com.microsoft.samples.subpackage.Person.IdentificationInfo</a></td>
 <td>
 Class that describes person's identification</td>
    </tr>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.subpackage.Tuple">com.microsoft.samples.subpackage.Tuple</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.subpackage.Tuple">com.microsoft.samples.subpackage.Tuple</a></td>
 <td>
 </td>
    </tr>
@@ -42,7 +46,7 @@ Interface</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.subpackage.Display">com.microsoft.samples.subpackage.Display</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.subpackage.Display">com.microsoft.samples.subpackage.Display</a></td>
 <td>
 Do you see some <code>First</code> code block?
 
@@ -58,7 +62,7 @@ Enum</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender">com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender">com.microsoft.samples.subpackage.Person.IdentificationInfo.Gender</a></td>
 <td>
 Enum describes person's gender</td>
    </tr>
@@ -72,7 +76,7 @@ Exception</th>
      <th>
 Description</th>
 <tr>
-<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/latest/com.microsoft.samples.subpackage.CustomException">com.microsoft.samples.subpackage.CustomException</a></td>
+<td><a href="https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.subpackage.CustomException">com.microsoft.samples.subpackage.CustomException</a></td>
 <td>
 </td>
    </tr>

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/overview.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/overview.md
@@ -87,12 +87,26 @@ To use the latest version of this library, add this to your dependencies:
 libraryDependencies += &quot;com.google.cloud&quot; % &quot;google-cloud-apikeys&quot; % &quot;0.18.0&quot;
 </pre>
 
-## Which version should I use?
-For this library, we recommend using API version v1 for new applications.
+## Which version ID should I get started with?
+For this library, we recommend using [com.microsoft.samples.google.v1](https://cloud.google.com/java/docs/reference/google-cloud-apikeys/0.18.0/com.microsoft.samples.google.v1) for new applications.
 
-Each Cloud Java client library may contain multiple packages. Each package containing a version number in its name corresponds to a published version of the service.
-We recommend using the latest stable version for new production applications, which can be identified by the largest numeric version that does not contain a suffix.
-For example, if a client library has two packages: `v1` and `v2alpha`, then the latest stable version is `v1`.
-If you use an unstable release, breaking changes may be introduced when upgrading.
-You can read more about [Cloud API versioning strategy here](https://cloud.google.com/apis/design/versioning).
+### Understanding Version ID and Library Versions
+When using a Cloud client library, it's important to distinguish between two types of versions:
+- **Library Version**: The version of the software package (the client library) that helps you interact with the Cloud service. These libraries are
+released and updated frequently with bug fixes, improvements, and support for new service features and versions. The version selector at
+the top of this page represents the client library version.
+- **Version ID**: The version of the Cloud service itself (e.g. API Keys API). New Version IDs are introduced infrequently, and often involve
+changes to the core functionality and structure of the Cloud service itself. The packages in the lefthand navigation represent packages tied
+to a specific Version ID of the Cloud service.
+
+### Managing Library Versions
+We recommend using the <code>com.google.cloud:libraries-bom</code> installation method detailed above to streamline dependency management
+across multiple Cloud Java client libraries. This ensures compatibility and simplifies updates.
+
+### Choosing the Right Version ID
+Each Cloud Java client library may contain packages tied to specific Version IDs (e.g., <code>v1</code>, <code>v2alpha</code>). For new production applications, use
+the latest stable Version ID. This is identified by the highest version number **without** a suffix (like "alpha" or "beta"). You can read more about
+[Cloud API versioning strategy here](https://cloud.google.com/apis/design/versioning).
+
+**Important**: Unstable Version ID releases (those _with_ suffixes) are subject to breaking changes when upgrading. Use them only for testing or if you specifically need their experimental features.
 


### PR DESCRIPTION
Fixes #228 

- Updates the "Which version ID should I get started with?" section of the Library Overview to include updated explanation as well as link to the *versioned* recommended package
- Also includes some small refactoring on explanations in general for Package overviews
- Removes unnecessary installation instructions for runtime modules such as gax

Mocks for datastore (including the new recommend package- this has yet to be implemented officially, but I tested this locally and it worked): cl/621600852

Mocks for gax (removes the installation instructions which are not needed - could use some more work, but wanted to do that as a separate PR): cl/616832035

Mocks for speech: cl/621648535