### PR TITLE
chore: update to v1.15.0 for release

### DIFF
--- a/third_party/docfx-doclet-143274/pom.xml
+++ b/third_party/docfx-doclet-143274/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.microsoft</groupId>
   <artifactId>docfx-doclet</artifactId>
-  <version>1.14.0-SNAPSHOT</version>
+  <version>1.15.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Follows release instructions: https://github.com/googleapis/java-docfx-doclet/tree/main/third_party/docfx-doclet-143274#release-guide

...and previous pattern: https://github.com/googleapis/java-docfx-doclet/commit/06fb50e3dec84535a7294e6db248ac49489633e4