### PR TITLE
chore: update to v1.16.0

### DIFF
--- a/third_party/docfx-doclet-143274/pom.xml
+++ b/third_party/docfx-doclet-143274/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.microsoft</groupId>
   <artifactId>docfx-doclet</artifactId>
-  <version>1.15.0-SNAPSHOT</version>
+  <version>1.16.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
GitHub release for [1.16.0 already completed](https://github.com/googleapis/java-docfx-doclet/releases/tag/v1.16.0). This pom.xml should have been included in that release.