### PR TITLE
fix: remove `(includes samples)` from overview link

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/LibraryOverviewFile.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/model/LibraryOverviewFile.java
@@ -87,7 +87,7 @@ public class LibraryOverviewFile {
             + " Product Reference</a></td>\n"
             + "     <td><a href=\""
             + repoMetadata.getGithubLink()
-            + "\">GitHub Repository (includes samples)</a></td>\n"
+            + "\">GitHub Repository</a></td>\n"
             + "     <td><a href=\""
             + repoMetadata.getMavenLink()
             + "\">Maven artifact</a></td>\n"

--- a/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/overview.md
+++ b/third_party/docfx-doclet-143274/src/test/resources/expected-generated-files/overview.md
@@ -6,7 +6,7 @@
 <table>
    <tr>
      <td><a href="https://cloud.google.com/api-keys/">API Keys API Product Reference</a></td>
-     <td><a href="https://github.com/googleapis/google-cloud-java/tree/main/java-apikeys">GitHub Repository (includes samples)</a></td>
+     <td><a href="https://github.com/googleapis/google-cloud-java/tree/main/java-apikeys">GitHub Repository</a></td>
      <td><a href="https://central.sonatype.com/artifact/com.google.cloud/google-cloud-apikeys">Maven artifact</a></td>
    </tr>
  </table>


### PR DESCRIPTION
b/404600681
The samples inside the GitHub repositories are not meant for user consumption and are better portrayed in https://cloud.google.com/docs/samples

see gpaste/5865295979479040 for final result tried locally against `java-spanner`. The relevant part is:


```html
<table>
   <tr>
     <td><a href="https://cloud.google.com/spanner/docs/">Cloud Spanner Product Reference</a></td>
     <td><a href="https://github.com/googleapis/java-spanner/tree/main/">GitHub Repository</a></td>
     <td><a href="https://central.sonatype.com/artifact/com.google.cloud/google-cloud-spanner">Maven artifact</a></td>
   </tr>
 </table>
```