### PR TITLE
fix: allow overriding source directory per class in GitHub links

### DIFF
--- a/third_party/docfx-doclet-143274/src/main/java/com/google/docfx/doclet/RepoMetadata.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/google/docfx/doclet/RepoMetadata.java
@@ -8,6 +8,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -48,6 +50,9 @@ public class RepoMetadata {
 
   @SerializedName("recommended_package")
   private String recommendedPackage;
+
+  @SerializedName("library_path_overrides")
+  private Map<String, String> libraryPathOverrides;
 
   private String artifactId;
 
@@ -133,6 +138,14 @@ public class RepoMetadata {
 
   public void setApiId(String apiId) {
     this.apiId = apiId;
+  }
+
+  public Map<String, String> getLibraryPathOverrides() {
+    return this.libraryPathOverrides != null ? this.libraryPathOverrides : Collections.emptyMap();
+  }
+
+  public void setLibraryPathOverrides(Map<String, String> libraryPathOverrides) {
+    this.libraryPathOverrides = libraryPathOverrides;
   }
 
   // artifactId is parsed from distributionName

--- a/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ClassBuilder.java
+++ b/third_party/docfx-doclet-143274/src/main/java/com/microsoft/build/ClassBuilder.java
@@ -248,13 +248,16 @@ class ClassBuilder {
 
   private String createClientOverviewTable(TypeElement classElement, RepoMetadata repoMetadata) {
     String clientURI = classLookup.extractUid(classElement).replaceAll("\\.", "/");
+    String className = classElement.getSimpleName().toString();
+
+    // Check overrides map first, otherwise default to artifactId
+    String directory =
+        repoMetadata
+            .getLibraryPathOverrides()
+            .getOrDefault(className, repoMetadata.getArtifactId());
+
     String githubSourceLink =
-        repoMetadata.getGithubLink()
-            + "/"
-            + repoMetadata.getArtifactId()
-            + "/src/main/java/"
-            + clientURI
-            + ".java";
+        repoMetadata.getGithubLink() + "/" + directory + "/src/main/java/" + clientURI + ".java";
     StringBuilder tableBuilder = new StringBuilder();
     tableBuilder
         .append("<table>")

--- a/third_party/docfx-doclet-143274/src/test/java/com/google/docfx/doclet/RepoMetadataTest.java
+++ b/third_party/docfx-doclet-143274/src/test/java/com/google/docfx/doclet/RepoMetadataTest.java
@@ -1,0 +1,29 @@
+package com.google.docfx.doclet;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+public class RepoMetadataTest {
+
+  @Test
+  public void testParseWithLibraryPathOverrides() {
+    String json =
+        "{ "
+            + "\"distribution_name\": \"com.google.cloud:google-cloud-firestore\", "
+            + "\"library_path_overrides\": { "
+            + "  \"FirestoreAdminClient\": \"google-cloud-firestore-admin\" "
+            + "}, "
+            + "\"repo\": \"googleapis/java-firestore\" "
+            + "}";
+
+    RepoMetadata metadata = new Gson().fromJson(json, RepoMetadata.class);
+
+    assertEquals("google-cloud-firestore", metadata.getArtifactId());
+    // Verify the map is populated correctly
+    assertEquals(
+        "google-cloud-firestore-admin",
+        metadata.getLibraryPathOverrides().get("FirestoreAdminClient"));
+  }
+}


### PR DESCRIPTION
Currently, the doclet assumes the source directory name matches the
artifact ID when generating GitHub links. This leads to broken links
for libraries where they differ, such as Firestore (artifact:
`google-cloud-firestore`, directory: `google-cloud-firestore-admin`
for `FirestoreAdminClient`).

This change adds an optional `library_path_overrides` map to
`RepoMetadata` and updates `ClassBuilder` to check this map using the
simple class name before falling back to the artifact ID.

Fixes: b/442875200